### PR TITLE
2/Implement recurring transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Recurring transactions with idempotent monthly generation: `coinw recurring`
+  (list, add, edit, delete rules, and generate due transactions)
+
 ## [0.1.0] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Local-first CLI tool for tracking personal finances.
 - Interactive transaction deletion: `coinw delete`
 - Interactive account management: `coinw account`
 - Monthly budgets with rollover: `coinw budget`
+- Recurring transactions with monthly cadence: `coinw recurring`
 - List transactions: `coinw list [range]`
 - Range report (balances + category): `coinw report <range> [--details]`
 

--- a/cmd/recurring.go
+++ b/cmd/recurring.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"github.com/amiraminb/coinwarrior/internal/tui"
+	"github.com/spf13/cobra"
+)
+
+var recurringCmd = &cobra.Command{
+	Use:   "recurring",
+	Short: "Manage recurring transactions",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return tui.RunRecurringAction()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(recurringCmd)
+}

--- a/internal/model/constants.go
+++ b/internal/model/constants.go
@@ -7,8 +7,9 @@ const (
 )
 
 const (
-	TransferCategory        = "Transfer"
-	TransactionSourceManual = "manual"
+	TransferCategory           = "Transfer"
+	TransactionSourceManual    = "manual"
+	TransactionSourceRecurring = "recurring"
 )
 
 const (

--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -23,6 +23,23 @@ type Account struct {
 	UpdatedAt    string `json:"updated_at"`
 }
 
+type RecurringRule struct {
+	ID                 string `json:"id"`
+	Type               string `json:"type"`
+	AmountMinor        int64  `json:"amount_minor"`
+	Currency           string `json:"currency"`
+	Category           string `json:"category"`
+	Account            string `json:"account"`
+	ToAccount          string `json:"to_account,omitempty"`
+	Note               string `json:"note,omitempty"`
+	DayOfMonth         int    `json:"day_of_month"`
+	StartDate          string `json:"start_date"`
+	EndDate            string `json:"end_date,omitempty"`
+	LastGeneratedMonth string `json:"last_generated_month,omitempty"`
+	CreatedAt          string `json:"created_at"`
+	UpdatedAt          string `json:"updated_at"`
+}
+
 type Budget struct {
 	Month               string `json:"month"`
 	Currency            string `json:"currency"`

--- a/internal/repository/recurring.go
+++ b/internal/repository/recurring.go
@@ -1,0 +1,29 @@
+package repository
+
+import "github.com/amiraminb/coinwarrior/internal/model"
+
+type recurringDocument struct {
+	SchemaVersion  int                   `json:"schema_version"`
+	RecurringRules []model.RecurringRule `json:"recurring_rules"`
+}
+
+func (r *FileRepository) LoadRecurringRules() ([]model.RecurringRule, error) {
+	path, err := r.DataFilePath(RecurringFileName)
+	if err != nil {
+		return nil, err
+	}
+	return loadDocument(path, func(d recurringDocument) []model.RecurringRule {
+		return d.RecurringRules
+	}, nil)
+}
+
+func (r *FileRepository) SaveRecurringRules(rules []model.RecurringRule) error {
+	path, err := r.DataFilePath(RecurringFileName)
+	if err != nil {
+		return err
+	}
+	if rules == nil {
+		rules = []model.RecurringRule{}
+	}
+	return saveDocument(path, recurringDocument{SchemaVersion: 1, RecurringRules: rules})
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -11,6 +11,8 @@ type Repository interface {
 	SaveCategories([]string) error
 	LoadBudgets() ([]model.Budget, error)
 	SaveBudgets([]model.Budget) error
+	LoadRecurringRules() ([]model.RecurringRule, error)
+	SaveRecurringRules([]model.RecurringRule) error
 }
 
 type FileRepository struct {

--- a/internal/service/recurring.go
+++ b/internal/service/recurring.go
@@ -1,0 +1,480 @@
+package service
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/amiraminb/coinwarrior/internal/daterange"
+	"github.com/amiraminb/coinwarrior/internal/model"
+	"github.com/amiraminb/coinwarrior/internal/money"
+)
+
+const (
+	recurringDayOfMonthMin = 1
+	recurringDayOfMonthMax = 28
+)
+
+type RecurringRuleInput struct {
+	Type        string
+	AmountInput string
+	Currency    string
+	Category    string
+	Account     string
+	ToAccount   string
+	Note        string
+	DayOfMonth  int
+	StartDate   string
+	EndDate     string
+}
+
+type RecurringRuleEdits struct {
+	Type        *string
+	AmountInput *string
+	Currency    *string
+	Category    *string
+	Account     *string
+	ToAccount   *string
+	Note        *string
+	DayOfMonth  *int
+	StartDate   *string
+	EndDate     *string
+}
+
+type GenerationResult struct {
+	Generated  []model.Transaction
+	RuleCounts map[string]int
+}
+
+func newRecurringRuleID(now time.Time) string {
+	return fmt.Sprintf("rec_%d", now.UnixNano())
+}
+
+func findRecurringRuleIndex(rules []model.RecurringRule, id string) int {
+	return slices.IndexFunc(rules, func(r model.RecurringRule) bool {
+		return r.ID == id
+	})
+}
+
+func (s *Service) LoadRecurringRules() ([]model.RecurringRule, error) {
+	rules, err := s.repo.LoadRecurringRules()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]model.RecurringRule, len(rules))
+	copy(out, rules)
+	return out, nil
+}
+
+func (s *Service) AddRecurringRule(input RecurringRuleInput) (model.RecurringRule, error) {
+	now := time.Now()
+	rule, err := buildRecurringRule(input, now)
+	if err != nil {
+		return model.RecurringRule{}, err
+	}
+
+	rules, err := s.repo.LoadRecurringRules()
+	if err != nil {
+		return model.RecurringRule{}, err
+	}
+	rules = append(rules, rule)
+	if err := s.repo.SaveRecurringRules(rules); err != nil {
+		return model.RecurringRule{}, err
+	}
+	return rule, nil
+}
+
+func (s *Service) EditRecurringRule(id string, edits RecurringRuleEdits) (model.RecurringRule, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return model.RecurringRule{}, fmt.Errorf("rule id is required")
+	}
+	rules, err := s.repo.LoadRecurringRules()
+	if err != nil {
+		return model.RecurringRule{}, err
+	}
+	idx := findRecurringRuleIndex(rules, id)
+	if idx == -1 {
+		return model.RecurringRule{}, fmt.Errorf("recurring rule '%s' not found", id)
+	}
+
+	now := time.Now()
+	updated, changed, err := applyRecurringRuleEdits(rules[idx], edits, now)
+	if err != nil {
+		return model.RecurringRule{}, err
+	}
+	if !changed {
+		return rules[idx], nil
+	}
+	rules[idx] = updated
+	if err := s.repo.SaveRecurringRules(rules); err != nil {
+		return model.RecurringRule{}, err
+	}
+	return updated, nil
+}
+
+func (s *Service) DeleteRecurringRule(id string) (model.RecurringRule, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return model.RecurringRule{}, fmt.Errorf("rule id is required")
+	}
+	rules, err := s.repo.LoadRecurringRules()
+	if err != nil {
+		return model.RecurringRule{}, err
+	}
+	idx := findRecurringRuleIndex(rules, id)
+	if idx == -1 {
+		return model.RecurringRule{}, fmt.Errorf("recurring rule '%s' not found", id)
+	}
+	deleted := rules[idx]
+	rules = append(rules[:idx], rules[idx+1:]...)
+	if err := s.repo.SaveRecurringRules(rules); err != nil {
+		return model.RecurringRule{}, err
+	}
+	return deleted, nil
+}
+
+func (s *Service) GenerateDueTransactions(now time.Time) (GenerationResult, error) {
+	result := GenerationResult{
+		Generated:  []model.Transaction{},
+		RuleCounts: make(map[string]int),
+	}
+
+	transactions, err := s.repo.LoadTransactions()
+	if err != nil {
+		return result, err
+	}
+	accounts, err := s.repo.LoadAccounts()
+	if err != nil {
+		return result, err
+	}
+	rules, err := s.repo.LoadRecurringRules()
+	if err != nil {
+		return result, err
+	}
+
+	originalAccounts := cloneAccounts(accounts)
+	originalRules := cloneRecurringRules(rules)
+	nowUTC := now.UTC().Format(time.RFC3339)
+	today := daterange.DateOnly(now)
+
+	idCounter := 0
+	for i := range rules {
+		dueTxs, err := dueTransactionsForRule(rules[i], today, now, nowUTC, &idCounter)
+		if err != nil {
+			return GenerationResult{}, err
+		}
+		for _, tx := range dueTxs {
+			if err := applyTransactionEffect(accounts, tx, nowUTC); err != nil {
+				return GenerationResult{}, err
+			}
+			transactions = append(transactions, tx)
+			result.Generated = append(result.Generated, tx)
+			result.RuleCounts[rules[i].ID]++
+		}
+		if len(dueTxs) > 0 {
+			lastTx := dueTxs[len(dueTxs)-1]
+			rules[i].LastGeneratedMonth = monthKeyFromDate(lastTx.Date)
+			rules[i].UpdatedAt = nowUTC
+		}
+	}
+
+	if len(result.Generated) == 0 {
+		return result, nil
+	}
+
+	if err := s.repo.SaveAccounts(accounts); err != nil {
+		return GenerationResult{}, err
+	}
+	if err := s.repo.SaveTransactions(transactions); err != nil {
+		if rbErr := s.repo.SaveAccounts(originalAccounts); rbErr != nil {
+			return GenerationResult{}, fmt.Errorf("save transactions: %w; rollback accounts: %v", err, rbErr)
+		}
+		return GenerationResult{}, err
+	}
+	if err := s.repo.SaveRecurringRules(rules); err != nil {
+		if rbErr := s.repo.SaveRecurringRules(originalRules); rbErr != nil {
+			_ = rbErr
+		}
+		if rbErr := s.repo.SaveAccounts(originalAccounts); rbErr != nil {
+			_ = rbErr
+		}
+		return GenerationResult{}, err
+	}
+
+	return result, nil
+}
+
+func buildRecurringRule(input RecurringRuleInput, now time.Time) (model.RecurringRule, error) {
+	txType := strings.TrimSpace(input.Type)
+	if txType != model.TransactionTypeExpense && txType != model.TransactionTypeIncome && txType != model.TransactionTypeTransfer {
+		return model.RecurringRule{}, fmt.Errorf("invalid transaction type: %s", txType)
+	}
+
+	amountMinor, err := money.Parse(input.AmountInput)
+	if err != nil {
+		return model.RecurringRule{}, err
+	}
+	if amountMinor <= 0 {
+		return model.RecurringRule{}, fmt.Errorf("amount must be greater than zero")
+	}
+
+	currency := money.NormalizeCurrency(input.Currency)
+	if currency == "" {
+		return model.RecurringRule{}, fmt.Errorf("currency is required")
+	}
+
+	day := input.DayOfMonth
+	if day < recurringDayOfMonthMin || day > recurringDayOfMonthMax {
+		return model.RecurringRule{}, fmt.Errorf("day of month must be between %d and %d", recurringDayOfMonthMin, recurringDayOfMonthMax)
+	}
+
+	start := strings.TrimSpace(input.StartDate)
+	if start == "" {
+		start = now.Format("2006-01-02")
+	}
+	if _, err := time.Parse("2006-01-02", start); err != nil {
+		return model.RecurringRule{}, fmt.Errorf("invalid start date: %s", input.StartDate)
+	}
+
+	end := strings.TrimSpace(input.EndDate)
+	if end != "" {
+		endTime, err := time.Parse("2006-01-02", end)
+		if err != nil {
+			return model.RecurringRule{}, fmt.Errorf("invalid end date: %s", input.EndDate)
+		}
+		startTime, _ := time.Parse("2006-01-02", start)
+		if endTime.Before(startTime) {
+			return model.RecurringRule{}, fmt.Errorf("end date is before start date")
+		}
+	}
+
+	account := strings.TrimSpace(input.Account)
+	toAccount := strings.TrimSpace(input.ToAccount)
+	category := strings.TrimSpace(input.Category)
+
+	if txType == model.TransactionTypeTransfer {
+		if account == "" || toAccount == "" {
+			return model.RecurringRule{}, fmt.Errorf("both source and destination accounts are required")
+		}
+		if strings.EqualFold(account, toAccount) {
+			return model.RecurringRule{}, fmt.Errorf("source and destination accounts must be different")
+		}
+		if category == "" {
+			category = model.TransferCategory
+		}
+	} else {
+		if account == "" {
+			return model.RecurringRule{}, fmt.Errorf("account is required")
+		}
+		toAccount = ""
+	}
+
+	utcNow := now.UTC().Format(time.RFC3339)
+	return model.RecurringRule{
+		ID:          newRecurringRuleID(now.UTC()),
+		Type:        txType,
+		AmountMinor: amountMinor,
+		Currency:    currency,
+		Category:    category,
+		Account:     account,
+		ToAccount:   toAccount,
+		Note:        strings.TrimSpace(input.Note),
+		DayOfMonth:  day,
+		StartDate:   start,
+		EndDate:     end,
+		CreatedAt:   utcNow,
+		UpdatedAt:   utcNow,
+	}, nil
+}
+
+func applyRecurringRuleEdits(rule model.RecurringRule, edits RecurringRuleEdits, now time.Time) (model.RecurringRule, bool, error) {
+	updated := rule
+	if edits.Type != nil {
+		updated.Type = *edits.Type
+	}
+	if edits.AmountInput != nil {
+		amountMinor, err := money.Parse(*edits.AmountInput)
+		if err != nil {
+			return model.RecurringRule{}, false, err
+		}
+		if amountMinor <= 0 {
+			return model.RecurringRule{}, false, fmt.Errorf("amount must be greater than zero")
+		}
+		updated.AmountMinor = amountMinor
+	}
+	if edits.Currency != nil {
+		updated.Currency = money.NormalizeCurrency(*edits.Currency)
+	}
+	if edits.Category != nil {
+		updated.Category = *edits.Category
+	}
+	if edits.Account != nil {
+		updated.Account = *edits.Account
+	}
+	if edits.ToAccount != nil {
+		updated.ToAccount = *edits.ToAccount
+	}
+	if edits.Note != nil {
+		updated.Note = *edits.Note
+	}
+	if edits.DayOfMonth != nil {
+		updated.DayOfMonth = *edits.DayOfMonth
+	}
+	if edits.StartDate != nil {
+		updated.StartDate = *edits.StartDate
+	}
+	if edits.EndDate != nil {
+		updated.EndDate = *edits.EndDate
+	}
+
+	updated.Type = strings.TrimSpace(updated.Type)
+	updated.Currency = money.NormalizeCurrency(updated.Currency)
+	updated.Account = strings.TrimSpace(updated.Account)
+	updated.ToAccount = strings.TrimSpace(updated.ToAccount)
+	updated.Category = strings.TrimSpace(updated.Category)
+	updated.Note = strings.TrimSpace(updated.Note)
+	updated.StartDate = strings.TrimSpace(updated.StartDate)
+	updated.EndDate = strings.TrimSpace(updated.EndDate)
+
+	if updated.Type != model.TransactionTypeExpense && updated.Type != model.TransactionTypeIncome && updated.Type != model.TransactionTypeTransfer {
+		return model.RecurringRule{}, false, fmt.Errorf("invalid transaction type: %s", updated.Type)
+	}
+	if updated.Currency == "" {
+		return model.RecurringRule{}, false, fmt.Errorf("currency is required")
+	}
+	if updated.DayOfMonth < recurringDayOfMonthMin || updated.DayOfMonth > recurringDayOfMonthMax {
+		return model.RecurringRule{}, false, fmt.Errorf("day of month must be between %d and %d", recurringDayOfMonthMin, recurringDayOfMonthMax)
+	}
+	if updated.StartDate == "" {
+		return model.RecurringRule{}, false, fmt.Errorf("start date is required")
+	}
+	if _, err := time.Parse("2006-01-02", updated.StartDate); err != nil {
+		return model.RecurringRule{}, false, fmt.Errorf("invalid start date: %s", updated.StartDate)
+	}
+	if updated.EndDate != "" {
+		endTime, err := time.Parse("2006-01-02", updated.EndDate)
+		if err != nil {
+			return model.RecurringRule{}, false, fmt.Errorf("invalid end date: %s", updated.EndDate)
+		}
+		startTime, _ := time.Parse("2006-01-02", updated.StartDate)
+		if endTime.Before(startTime) {
+			return model.RecurringRule{}, false, fmt.Errorf("end date is before start date")
+		}
+	}
+
+	if updated.Type == model.TransactionTypeTransfer {
+		if updated.Account == "" || updated.ToAccount == "" {
+			return model.RecurringRule{}, false, fmt.Errorf("both source and destination accounts are required")
+		}
+		if strings.EqualFold(updated.Account, updated.ToAccount) {
+			return model.RecurringRule{}, false, fmt.Errorf("source and destination accounts must be different")
+		}
+		if updated.Category == "" {
+			updated.Category = model.TransferCategory
+		}
+	} else {
+		if updated.Account == "" {
+			return model.RecurringRule{}, false, fmt.Errorf("account is required")
+		}
+		updated.ToAccount = ""
+	}
+
+	changed := updated.Type != rule.Type ||
+		updated.AmountMinor != rule.AmountMinor ||
+		updated.Currency != rule.Currency ||
+		updated.Category != rule.Category ||
+		updated.Account != rule.Account ||
+		updated.ToAccount != rule.ToAccount ||
+		updated.Note != rule.Note ||
+		updated.DayOfMonth != rule.DayOfMonth ||
+		updated.StartDate != rule.StartDate ||
+		updated.EndDate != rule.EndDate
+	if !changed {
+		return rule, false, nil
+	}
+
+	updated.UpdatedAt = now.UTC().Format(time.RFC3339)
+	return updated, true, nil
+}
+
+func dueTransactionsForRule(rule model.RecurringRule, today, now time.Time, nowUTC string, idCounter *int) ([]model.Transaction, error) {
+	startTime, err := time.Parse("2006-01-02", rule.StartDate)
+	if err != nil {
+		return nil, fmt.Errorf("rule %s: invalid start date: %s", rule.ID, rule.StartDate)
+	}
+	startMonth := time.Date(startTime.Year(), startTime.Month(), 1, 0, 0, 0, 0, today.Location())
+
+	cursor := startMonth
+	if rule.LastGeneratedMonth != "" {
+		last, err := time.ParseInLocation("2006-01", rule.LastGeneratedMonth, today.Location())
+		if err != nil {
+			return nil, fmt.Errorf("rule %s: invalid last_generated_month: %s", rule.ID, rule.LastGeneratedMonth)
+		}
+		next := last.AddDate(0, 1, 0)
+		if next.After(cursor) {
+			cursor = next
+		}
+	}
+
+	var endLimit *time.Time
+	if rule.EndDate != "" {
+		endTime, err := time.Parse("2006-01-02", rule.EndDate)
+		if err != nil {
+			return nil, fmt.Errorf("rule %s: invalid end date: %s", rule.ID, rule.EndDate)
+		}
+		endLimit = &endTime
+	}
+
+	var due []model.Transaction
+	currentMonth := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, today.Location())
+	for !cursor.After(currentMonth) {
+		txDate := time.Date(cursor.Year(), cursor.Month(), rule.DayOfMonth, 0, 0, 0, 0, today.Location())
+		if txDate.After(today) {
+			break
+		}
+		if endLimit != nil && txDate.After(*endLimit) {
+			break
+		}
+		startBoundary, _ := time.Parse("2006-01-02", rule.StartDate)
+		if txDate.Before(startBoundary) {
+			cursor = cursor.AddDate(0, 1, 0)
+			continue
+		}
+
+		txTime := now.Add(time.Duration(*idCounter) * time.Nanosecond)
+		*idCounter++
+		tx := model.Transaction{
+			ID:          NewTransactionID(txTime.UTC()),
+			Type:        rule.Type,
+			AmountMinor: rule.AmountMinor,
+			Currency:    rule.Currency,
+			Date:        txDate.Format("2006-01-02"),
+			Category:    rule.Category,
+			Account:     rule.Account,
+			ToAccount:   rule.ToAccount,
+			Note:        rule.Note,
+			CreatedAt:   nowUTC,
+			UpdatedAt:   nowUTC,
+			Source:      model.TransactionSourceRecurring,
+		}
+		due = append(due, tx)
+		cursor = cursor.AddDate(0, 1, 0)
+	}
+
+	return due, nil
+}
+
+func monthKeyFromDate(date string) string {
+	if len(date) >= 7 {
+		return date[:7]
+	}
+	return date
+}
+
+func cloneRecurringRules(rules []model.RecurringRule) []model.RecurringRule {
+	out := make([]model.RecurringRule, len(rules))
+	copy(out, rules)
+	return out
+}

--- a/internal/tui/recurring.go
+++ b/internal/tui/recurring.go
@@ -1,0 +1,724 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/amiraminb/coinwarrior/internal/model"
+	"github.com/amiraminb/coinwarrior/internal/money"
+	"github.com/amiraminb/coinwarrior/internal/service"
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type recurringAction string
+
+const (
+	recurringActionList     recurringAction = "list"
+	recurringActionAdd      recurringAction = "add"
+	recurringActionEdit     recurringAction = "edit"
+	recurringActionDelete   recurringAction = "delete"
+	recurringActionGenerate recurringAction = "generate"
+	recurringActionQuit     recurringAction = "quit"
+)
+
+func RunRecurringAction() error {
+	items := []selectionItem[recurringAction]{
+		{label: "List rules", value: recurringActionList},
+		{label: "Add rule", value: recurringActionAdd},
+		{label: "Edit rule", value: recurringActionEdit},
+		{label: "Delete rule", value: recurringActionDelete},
+		{label: "Generate due transactions", value: recurringActionGenerate},
+		{label: "Quit", value: recurringActionQuit},
+	}
+	action, ok, err := runSelection("Recurring Transactions", "Choose an action:", items)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
+	switch action {
+	case recurringActionList:
+		return runRecurringList()
+	case recurringActionAdd:
+		_, err := runRecurringAdd()
+		return err
+	case recurringActionEdit:
+		_, err := runRecurringEdit()
+		return err
+	case recurringActionDelete:
+		_, err := runRecurringDelete()
+		return err
+	case recurringActionGenerate:
+		return runRecurringGenerate()
+	case recurringActionQuit:
+		return nil
+	default:
+		fmt.Println("recurring cancelled")
+		return nil
+	}
+}
+
+func runRecurringList() error {
+	rules, err := Svc.LoadRecurringRules()
+	if err != nil {
+		return err
+	}
+	if len(rules) == 0 {
+		fmt.Println("no recurring rules")
+		return nil
+	}
+
+	rows := make([]table.Row, 0, len(rules))
+	for _, rule := range rules {
+		account := rule.Account
+		if rule.Type == model.TransactionTypeTransfer {
+			account = rule.Account + " -> " + rule.ToAccount
+		}
+		end := rule.EndDate
+		if end == "" {
+			end = "-"
+		}
+		last := rule.LastGeneratedMonth
+		if last == "" {
+			last = "-"
+		}
+		rows = append(rows, table.Row{
+			rule.ID,
+			rule.Type,
+			money.Format(rule.AmountMinor),
+			rule.Currency,
+			rule.Category,
+			account,
+			strconv.Itoa(rule.DayOfMonth),
+			rule.StartDate,
+			end,
+			last,
+		})
+	}
+
+	RenderTable(
+		[]table.Column{
+			{Title: "ID", Width: 24},
+			{Title: "TYPE", Width: 8},
+			{Title: "AMOUNT", Width: 12},
+			{Title: "CUR", Width: 5},
+			{Title: "CATEGORY", Width: 14},
+			{Title: "ACCOUNT", Width: 22},
+			{Title: "DAY", Width: 4},
+			{Title: "START", Width: 10},
+			{Title: "END", Width: 10},
+			{Title: "LAST GEN", Width: 10},
+		},
+		rows,
+	)
+	return nil
+}
+
+type recurringField int
+
+const (
+	recurringFieldType recurringField = iota
+	recurringFieldAmount
+	recurringFieldCurrency
+	recurringFieldCategory
+	recurringFieldAccount
+	recurringFieldToAccount
+	recurringFieldDayOfMonth
+	recurringFieldStartDate
+	recurringFieldEndDate
+	recurringFieldNote
+	recurringFieldConfirm
+	recurringFieldDone
+)
+
+type recurringFormModel struct {
+	step           recurringField
+	typeChoices    []string
+	typeCursor     int
+	amountInput    string
+	currencyInput  string
+	categoryInput  string
+	accountInput   string
+	toAccountInput string
+	dayInput       string
+	startInput     string
+	endInput       string
+	noteInput      string
+	confirmCursor  int
+	confirmed      bool
+	errMessage     string
+	editingID      string // empty for add
+}
+
+func newRecurringAddFormModel() recurringFormModel {
+	return recurringFormModel{
+		step:          recurringFieldType,
+		typeChoices:   []string{model.TransactionTypeExpense, model.TransactionTypeIncome, model.TransactionTypeTransfer},
+		currencyInput: "CAD",
+		startInput:    time.Now().Format("2006-01-02"),
+		dayInput:      "1",
+	}
+}
+
+func newRecurringEditFormModel(rule model.RecurringRule) recurringFormModel {
+	typeIdx := 0
+	choices := []string{model.TransactionTypeExpense, model.TransactionTypeIncome, model.TransactionTypeTransfer}
+	for i, c := range choices {
+		if c == rule.Type {
+			typeIdx = i
+			break
+		}
+	}
+	return recurringFormModel{
+		step:           recurringFieldType,
+		typeChoices:    choices,
+		typeCursor:     typeIdx,
+		amountInput:    formatRuleAmountInput(rule.AmountMinor),
+		currencyInput:  rule.Currency,
+		categoryInput:  rule.Category,
+		accountInput:   rule.Account,
+		toAccountInput: rule.ToAccount,
+		dayInput:       strconv.Itoa(rule.DayOfMonth),
+		startInput:     rule.StartDate,
+		endInput:       rule.EndDate,
+		noteInput:      rule.Note,
+		editingID:      rule.ID,
+	}
+}
+
+func formatRuleAmountInput(amountMinor int64) string {
+	whole := amountMinor / 100
+	fraction := amountMinor % 100
+	return fmt.Sprintf("%d.%02d", whole, fraction)
+}
+
+func (m recurringFormModel) Init() tea.Cmd { return nil }
+
+func (m recurringFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+		}
+
+		switch m.step {
+		case recurringFieldType:
+			switch msg.String() {
+			case "up", "k":
+				if m.typeCursor > 0 {
+					m.typeCursor--
+				}
+			case "down", "j":
+				if m.typeCursor < len(m.typeChoices)-1 {
+					m.typeCursor++
+				}
+			case "enter":
+				m.step = recurringFieldAmount
+			case "esc":
+				return m, tea.Quit
+			}
+		case recurringFieldAmount:
+			switch msg.String() {
+			case "enter":
+				if _, err := money.Parse(m.amountInput); err != nil {
+					m.errMessage = err.Error()
+					break
+				}
+				m.errMessage = ""
+				m.step = recurringFieldCurrency
+			case "esc":
+				m.step = recurringFieldType
+			case "backspace":
+				m.errMessage = ""
+				if len(m.amountInput) > 0 {
+					m.amountInput = m.amountInput[:len(m.amountInput)-1]
+				}
+			default:
+				if len(msg.String()) == 1 {
+					ch := msg.String()
+					if (ch >= "0" && ch <= "9") || ch == "." {
+						m.amountInput += ch
+					}
+				}
+			}
+		case recurringFieldCurrency:
+			switch msg.String() {
+			case "enter":
+				if strings.TrimSpace(m.currencyInput) == "" {
+					m.errMessage = "currency is required"
+					break
+				}
+				m.errMessage = ""
+				m.step = recurringFieldCategory
+			case "esc":
+				m.step = recurringFieldAmount
+			case "backspace":
+				if len(m.currencyInput) > 0 {
+					m.currencyInput = m.currencyInput[:len(m.currencyInput)-1]
+				}
+			default:
+				if len(msg.String()) == 1 {
+					ch := strings.ToUpper(msg.String())
+					if len(m.currencyInput) < 3 && ch >= "A" && ch <= "Z" {
+						m.currencyInput += ch
+					}
+				}
+			}
+		case recurringFieldCategory:
+			switch msg.String() {
+			case "enter":
+				m.errMessage = ""
+				m.step = recurringFieldAccount
+			case "esc":
+				m.step = recurringFieldCurrency
+			case "backspace":
+				if len(m.categoryInput) > 0 {
+					m.categoryInput = m.categoryInput[:len(m.categoryInput)-1]
+				}
+			default:
+				if len(msg.String()) == 1 {
+					m.categoryInput += msg.String()
+				}
+			}
+		case recurringFieldAccount:
+			switch msg.String() {
+			case "enter":
+				if strings.TrimSpace(m.accountInput) == "" {
+					m.errMessage = "account is required"
+					break
+				}
+				m.errMessage = ""
+				if m.typeChoices[m.typeCursor] == model.TransactionTypeTransfer {
+					m.step = recurringFieldToAccount
+				} else {
+					m.step = recurringFieldDayOfMonth
+				}
+			case "esc":
+				m.step = recurringFieldCategory
+			case "backspace":
+				if len(m.accountInput) > 0 {
+					m.accountInput = m.accountInput[:len(m.accountInput)-1]
+				}
+			default:
+				if len(msg.String()) == 1 {
+					m.accountInput += msg.String()
+				}
+			}
+		case recurringFieldToAccount:
+			switch msg.String() {
+			case "enter":
+				if strings.TrimSpace(m.toAccountInput) == "" {
+					m.errMessage = "destination account is required"
+					break
+				}
+				m.errMessage = ""
+				m.step = recurringFieldDayOfMonth
+			case "esc":
+				m.step = recurringFieldAccount
+			case "backspace":
+				if len(m.toAccountInput) > 0 {
+					m.toAccountInput = m.toAccountInput[:len(m.toAccountInput)-1]
+				}
+			default:
+				if len(msg.String()) == 1 {
+					m.toAccountInput += msg.String()
+				}
+			}
+		case recurringFieldDayOfMonth:
+			switch msg.String() {
+			case "enter":
+				day, err := strconv.Atoi(strings.TrimSpace(m.dayInput))
+				if err != nil || day < 1 || day > 28 {
+					m.errMessage = "day of month must be between 1 and 28"
+					break
+				}
+				m.errMessage = ""
+				m.step = recurringFieldStartDate
+			case "esc":
+				if m.typeChoices[m.typeCursor] == model.TransactionTypeTransfer {
+					m.step = recurringFieldToAccount
+				} else {
+					m.step = recurringFieldAccount
+				}
+			case "backspace":
+				m.errMessage = ""
+				if len(m.dayInput) > 0 {
+					m.dayInput = m.dayInput[:len(m.dayInput)-1]
+				}
+			default:
+				if len(msg.String()) == 1 {
+					ch := msg.String()
+					if ch >= "0" && ch <= "9" {
+						m.dayInput += ch
+					}
+				}
+			}
+		case recurringFieldStartDate:
+			switch msg.String() {
+			case "enter":
+				if _, err := time.Parse("2006-01-02", strings.TrimSpace(m.startInput)); err != nil {
+					m.errMessage = "invalid date format (YYYY-MM-DD)"
+					break
+				}
+				m.errMessage = ""
+				m.step = recurringFieldEndDate
+			case "esc":
+				m.step = recurringFieldDayOfMonth
+			case "backspace":
+				m.errMessage = ""
+				if len(m.startInput) > 0 {
+					m.startInput = m.startInput[:len(m.startInput)-1]
+				}
+			default:
+				if len(msg.String()) == 1 {
+					ch := msg.String()
+					if (ch >= "0" && ch <= "9") || ch == "-" {
+						m.startInput += ch
+					}
+				}
+			}
+		case recurringFieldEndDate:
+			switch msg.String() {
+			case "enter":
+				if e := strings.TrimSpace(m.endInput); e != "" {
+					if _, err := time.Parse("2006-01-02", e); err != nil {
+						m.errMessage = "invalid date format (YYYY-MM-DD), or leave blank"
+						break
+					}
+				}
+				m.errMessage = ""
+				m.step = recurringFieldNote
+			case "esc":
+				m.step = recurringFieldStartDate
+			case "backspace":
+				m.errMessage = ""
+				if len(m.endInput) > 0 {
+					m.endInput = m.endInput[:len(m.endInput)-1]
+				}
+			default:
+				if len(msg.String()) == 1 {
+					ch := msg.String()
+					if (ch >= "0" && ch <= "9") || ch == "-" {
+						m.endInput += ch
+					}
+				}
+			}
+		case recurringFieldNote:
+			switch msg.String() {
+			case "enter":
+				m.confirmCursor = 0
+				m.step = recurringFieldConfirm
+			case "esc":
+				m.step = recurringFieldEndDate
+			case "backspace":
+				if len(m.noteInput) > 0 {
+					m.noteInput = m.noteInput[:len(m.noteInput)-1]
+				}
+			default:
+				if len(msg.String()) == 1 {
+					m.noteInput += msg.String()
+				}
+			}
+		case recurringFieldConfirm:
+			switch msg.String() {
+			case "left", "h", "up", "k":
+				m.confirmCursor = 0
+			case "right", "l", "down", "j":
+				m.confirmCursor = 1
+			case "enter":
+				if m.confirmCursor == 0 {
+					m.confirmed = true
+					m.step = recurringFieldDone
+					return m, tea.Quit
+				}
+				m.step = recurringFieldNote
+			case "esc":
+				m.step = recurringFieldNote
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m recurringFormModel) View() string {
+	title := "Add Recurring Rule"
+	if m.editingID != "" {
+		title = "Edit Recurring Rule"
+	}
+	s := title + "\n\n"
+
+	switch m.step {
+	case recurringFieldType:
+		s += "Select type:\n\n"
+		for i, c := range m.typeChoices {
+			line := "  " + c
+			if i == m.typeCursor {
+				line = focusStyle.Render("> " + c)
+			}
+			s += line + "\n"
+		}
+		s += "\n" + mutedStyle.Render("(↑/↓ enter, esc to cancel, q to quit)") + "\n"
+	case recurringFieldAmount:
+		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n\n"
+		s += renderActiveField("Amount: ", m.amountInput) + "\n"
+		s += renderError(m.errMessage)
+		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	case recurringFieldCurrency:
+		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n"
+		s += renderField("Amount: ", m.amountInput) + "\n\n"
+		s += renderActiveField("Currency: ", m.currencyInput) + "\n"
+		s += renderError(m.errMessage)
+		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	case recurringFieldCategory:
+		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n"
+		s += renderField("Amount: ", m.amountInput) + "\n"
+		s += renderField("Currency: ", m.currencyInput) + "\n\n"
+		s += renderActiveField("Category: ", m.categoryInput) + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	case recurringFieldAccount:
+		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n"
+		s += renderField("Amount: ", m.amountInput) + "\n"
+		s += renderField("Currency: ", m.currencyInput) + "\n"
+		s += renderField("Category: ", m.categoryInput) + "\n\n"
+		label := "Account: "
+		if m.typeChoices[m.typeCursor] == model.TransactionTypeTransfer {
+			label = "From account: "
+		}
+		s += renderActiveField(label, m.accountInput) + "\n"
+		s += renderError(m.errMessage)
+		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	case recurringFieldToAccount:
+		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n"
+		s += renderField("Amount: ", m.amountInput) + "\n"
+		s += renderField("From account: ", m.accountInput) + "\n\n"
+		s += renderActiveField("To account: ", m.toAccountInput) + "\n"
+		s += renderError(m.errMessage)
+		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	case recurringFieldDayOfMonth:
+		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n"
+		s += renderField("Amount: ", m.amountInput) + "\n"
+		s += renderField("Account: ", m.accountInput) + "\n\n"
+		s += renderActiveField("Day of month (1-28): ", m.dayInput) + "\n"
+		s += renderError(m.errMessage)
+		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	case recurringFieldStartDate:
+		s += renderField("Day of month: ", m.dayInput) + "\n\n"
+		s += renderActiveField("Start date (YYYY-MM-DD): ", m.startInput) + "\n"
+		s += renderError(m.errMessage)
+		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	case recurringFieldEndDate:
+		s += renderField("Start date: ", m.startInput) + "\n\n"
+		s += renderActiveField("End date (YYYY-MM-DD, blank for none): ", m.endInput) + "\n"
+		s += renderError(m.errMessage)
+		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	case recurringFieldNote:
+		s += renderActiveField("Note (optional): ", m.noteInput) + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	case recurringFieldConfirm:
+		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n"
+		s += renderField("Amount: ", m.amountInput) + " " + m.currencyInput + "\n"
+		s += renderField("Category: ", m.categoryInput) + "\n"
+		if m.typeChoices[m.typeCursor] == model.TransactionTypeTransfer {
+			s += renderField("From -> To: ", m.accountInput+" -> "+m.toAccountInput) + "\n"
+		} else {
+			s += renderField("Account: ", m.accountInput) + "\n"
+		}
+		s += renderField("Day of month: ", m.dayInput) + "\n"
+		s += renderField("Start: ", m.startInput) + "\n"
+		end := m.endInput
+		if end == "" {
+			end = "(none)"
+		}
+		s += renderField("End: ", end) + "\n"
+		if m.noteInput != "" {
+			s += renderField("Note: ", m.noteInput) + "\n"
+		}
+		s += "\n" + warnStyle.Render("Save recurring rule?") + "\n\n"
+		s += renderYesNo(m.confirmCursor == 0) + "\n"
+		s += mutedStyle.Render("(use ←/→ or ↑/↓, enter to confirm, esc to go back, q to quit)") + "\n"
+	case recurringFieldDone:
+		s += mutedStyle.Render("Done") + "\n"
+	}
+	return s
+}
+
+func runRecurringAdd() (bool, error) {
+	p := tea.NewProgram(newRecurringAddFormModel())
+	finalModel, err := p.Run()
+	if err != nil {
+		return false, err
+	}
+	result := finalModel.(recurringFormModel)
+	if !result.confirmed {
+		fmt.Println("recurring add cancelled")
+		return false, nil
+	}
+
+	day, _ := strconv.Atoi(strings.TrimSpace(result.dayInput))
+	input := service.RecurringRuleInput{
+		Type:        result.typeChoices[result.typeCursor],
+		AmountInput: result.amountInput,
+		Currency:    result.currencyInput,
+		Category:    result.categoryInput,
+		Account:     result.accountInput,
+		ToAccount:   result.toAccountInput,
+		Note:        result.noteInput,
+		DayOfMonth:  day,
+		StartDate:   result.startInput,
+		EndDate:     result.endInput,
+	}
+	rule, err := Svc.AddRecurringRule(input)
+	if err != nil {
+		return false, err
+	}
+	fmt.Printf("recurring rule created: %s\n", rule.ID)
+	return true, nil
+}
+
+func runRecurringEdit() (bool, error) {
+	rule, ok, err := pickRecurringRule("Edit Recurring Rule")
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		fmt.Println("edit cancelled")
+		return false, nil
+	}
+
+	p := tea.NewProgram(newRecurringEditFormModel(rule))
+	finalModel, err := p.Run()
+	if err != nil {
+		return false, err
+	}
+	result := finalModel.(recurringFormModel)
+	if !result.confirmed {
+		fmt.Println("edit cancelled")
+		return false, nil
+	}
+
+	day, _ := strconv.Atoi(strings.TrimSpace(result.dayInput))
+	txType := result.typeChoices[result.typeCursor]
+	currency := result.currencyInput
+	category := result.categoryInput
+	account := result.accountInput
+	toAccount := result.toAccountInput
+	note := result.noteInput
+	start := result.startInput
+	end := result.endInput
+	edits := service.RecurringRuleEdits{
+		Type:       &txType,
+		Currency:   &currency,
+		Category:   &category,
+		Account:    &account,
+		ToAccount:  &toAccount,
+		Note:       &note,
+		DayOfMonth: &day,
+		StartDate:  &start,
+		EndDate:    &end,
+	}
+	amount := result.amountInput
+	edits.AmountInput = &amount
+
+	updated, err := Svc.EditRecurringRule(rule.ID, edits)
+	if err != nil {
+		return false, err
+	}
+	fmt.Printf("recurring rule updated: %s\n", updated.ID)
+	return true, nil
+}
+
+func runRecurringDelete() (bool, error) {
+	rule, ok, err := pickRecurringRule("Delete Recurring Rule")
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		fmt.Println("delete cancelled")
+		return false, nil
+	}
+
+	confirmed, err := RunConfirmPrompt("Delete this recurring rule?\n" + formatRecurringRuleSummary(rule))
+	if err != nil {
+		return false, err
+	}
+	if !confirmed {
+		fmt.Println("delete cancelled")
+		return false, nil
+	}
+
+	deleted, err := Svc.DeleteRecurringRule(rule.ID)
+	if err != nil {
+		return false, err
+	}
+	fmt.Printf("recurring rule deleted: %s\n", deleted.ID)
+	return true, nil
+}
+
+func runRecurringGenerate() error {
+	result, err := Svc.GenerateDueTransactions(time.Now())
+	if err != nil {
+		return err
+	}
+	if len(result.Generated) == 0 {
+		fmt.Println("no due transactions")
+		return nil
+	}
+	fmt.Printf("generated %d transaction(s) from %d rule(s)\n", len(result.Generated), len(result.RuleCounts))
+	for _, tx := range result.Generated {
+		fmt.Printf("  %s %s %s %s %s %s\n", tx.ID, tx.Date, tx.Type, money.Format(tx.AmountMinor), tx.Currency, tx.Category)
+	}
+	return nil
+}
+
+func pickRecurringRule(title string) (model.RecurringRule, bool, error) {
+	rules, err := Svc.LoadRecurringRules()
+	if err != nil {
+		return model.RecurringRule{}, false, err
+	}
+	if len(rules) == 0 {
+		return model.RecurringRule{}, false, fmt.Errorf("no recurring rules available")
+	}
+
+	items := make([]selectionItem[string], 0, len(rules))
+	for _, rule := range rules {
+		items = append(items, selectionItem[string]{
+			label: formatRecurringRuleSummary(rule),
+			value: rule.ID,
+		})
+	}
+	id, ok, err := runSelection(title, "Select rule:", items)
+	if err != nil {
+		return model.RecurringRule{}, false, err
+	}
+	if !ok {
+		return model.RecurringRule{}, false, nil
+	}
+	for _, rule := range rules {
+		if rule.ID == id {
+			return rule, true, nil
+		}
+	}
+	return model.RecurringRule{}, false, fmt.Errorf("rule not found")
+}
+
+func formatRecurringRuleSummary(rule model.RecurringRule) string {
+	account := rule.Account
+	if rule.Type == model.TransactionTypeTransfer {
+		account = rule.Account + " -> " + rule.ToAccount
+	}
+	return fmt.Sprintf("%s | %s %s | %s | %s | day %d | from %s",
+		rule.Type,
+		money.Format(rule.AmountMinor),
+		rule.Currency,
+		rule.Category,
+		account,
+		rule.DayOfMonth,
+		rule.StartDate,
+	)
+}


### PR DESCRIPTION
## Summary

- Adds `coinw recurring` command with full CRUD over recurring rules and a generate action
- Supports monthly cadence (day-of-month 1-28) with optional start/end dates
- Idempotent generation: each rule tracks `last_generated_month`, so re-running `Generate due transactions` never duplicates

Closes #2

## Architecture

Layered across the existing packages:

- `internal/model`: `RecurringRule` struct, `TransactionSourceRecurring` constant
- `internal/repository`: `LoadRecurringRules` / `SaveRecurringRules` (uses existing `loadDocument` / `saveDocument` generics)
- `internal/service`: `AddRecurringRule`, `EditRecurringRule`, `DeleteRecurringRule`, `LoadRecurringRules`, and `GenerateDueTransactions` (the engine)
- `internal/tui`: `RunRecurringAction` top menu plus list/add/edit/delete/generate sub-flows
- `cmd/recurring.go`: thin cobra shell

## Generation behaviour

For each rule, walk months from `max(StartDate's month, LastGeneratedMonth+1)` through the current month (capped at `EndDate` if set). For each month, build a transaction dated `YYYY-MM-<day>`; skip months where that date is still in the future. Generated transactions get `Source: "recurring"`. Atomic save of (transactions, accounts, rules) with rollback on failure.

## Test plan

- [ ] `coinw recurring` shows the menu
- [ ] Adding a rule (expense, income, transfer) persists and shows in `List rules`
- [ ] Editing a rule changes the values shown in `List rules`
- [ ] Deleting a rule removes it
- [ ] `Generate due transactions` with no due rules prints "no due transactions"
- [ ] Backfill: create a rule with start date several months in the past, then generate — produces one transaction per past month
- [ ] Idempotency: running generate twice in a row produces the same result the second time (no new transactions)
- [ ] End date: rule with end date in the past stops generating beyond the end
- [ ] Account balances reflect the generated transactions
- [ ] `coinw list` shows the generated transactions with `source: recurring`