### PR TITLE
Harden data persistence durability and confidentiality

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -33,7 +33,7 @@ var initCmd = &cobra.Command{
 			return err
 		}
 
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
 

--- a/internal/repository/document.go
+++ b/internal/repository/document.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path/filepath"
+	"syscall"
 )
 
 func loadDocument[T any, D any](path string, extract func(D) []T, missingDefault func() []T) ([]T, error) {
@@ -31,6 +33,9 @@ func loadDocument[T any, D any](path string, extract func(D) []T, missingDefault
 	return items, nil
 }
 
+// saveDocument writes document to path atomically and durably: it marshals to a
+// uniquely named temp file in the same directory (0600), fsyncs the file, renames
+// it over path, then fsyncs the directory so the rename survives a crash.
 func saveDocument[D any](path string, document D) error {
 	data, err := json.MarshalIndent(document, "", "  ")
 	if err != nil {
@@ -38,10 +43,53 @@ func saveDocument[D any](path string, document D) error {
 	}
 	data = append(data, '\n')
 
-	tmpPath := path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o644); err != nil {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 
-	return os.Rename(tmpPath, path)
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	// Best-effort cleanup; a no-op once the rename succeeds.
+	defer os.Remove(tmpPath)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+
+	return syncDir(dir)
+}
+
+// syncDir flushes a directory's entries to disk so a rename into it survives a
+// crash. Failing to sync a directory is tolerated only when the filesystem does
+// not support it (EINVAL/ENOTSUP); all other failures propagate, since a missed
+// directory sync silently voids the crash-durability guarantee.
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	if err := d.Sync(); err != nil {
+		if errors.Is(err, syscall.EINVAL) || errors.Is(err, syscall.ENOTSUP) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }

--- a/internal/repository/file.go
+++ b/internal/repository/file.go
@@ -50,7 +50,10 @@ func (r *FileRepository) CreateFile(fileName string, content []byte) (string, bo
 	} else if !os.IsNotExist(err) {
 		return path, false, err
 	}
-	if err := os.WriteFile(path, content, 0o644); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return path, false, err
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
 		return path, false, err
 	}
 


### PR DESCRIPTION
## Summary

Coinwarrior's entire job is durably storing financial records, but the previous JSON write path could lose or expose data. This PR closes three data-safety gaps in the repository layer.

- **Crash-safe writes** — `saveDocument` now writes to a uniquely named temp file, `fsync`s it, renames it over the target, then `fsync`s the parent directory so the rename survives a crash. Previously it wrote with a fixed `.tmp` path and no `fsync`, so a crash mid-write could leave a truncated or zero-length ledger.
- **Correct durability tolerance** — `syncDir` tolerates only `EINVAL`/`ENOTSUP` (filesystems that don't support directory `fsync`); every other failure propagates instead of silently voiding the crash-durability guarantee.
- **Confidentiality** — data files are now `0600` and the data dir `0700` (was `0644`/`0755`). The store holds personal financial data and should not be world-readable.
- **Self-initializing** — `saveDocument` and `CreateFile` `MkdirAll` the data dir, so interactive commands (`add`, `budget`, `recurring`) no longer complete the whole TUI and then fail with a raw filesystem error when run before `init`.

## Why this approach

- `os.CreateTemp` (unique suffix) over the old fixed `path + ".tmp"` removes a concurrent-write collision footgun and creates the temp at `0600` by default, so there is no world-readable window before the rename. Trade-off: a hard crash mid-write can leave a stray temp file, but every error path cleans up via `defer os.Remove`, and the random suffix means no stale-file reuse hazard.
- Propagating non-EINVAL/ENOTSUP sync errors (rather than swallowing all open/sync failures) keeps the durability contract honest — a missed directory sync would otherwise report success while leaving the rename non-durable.

## Testing

- `go build ./...` and `GOOS=linux go build ./...` (both goreleaser targets) pass; `go vet` and `gofmt` clean on the changed files.
- Verified end-to-end against a scratch harness: content written correctly, file mode `0600`, dir mode `0700`, no leftover temp files, and a non-existent nested data dir is created on first save.

## Scope note

This is durability + confidentiality hardening. It does **not** implement the cross-process write locking tracked in #3 — two concurrent `coinw` processes can still lose updates (last rename wins). That remains a separate follow-up.