### PR TITLE
Clean up CLI error output and validate list range early

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -24,6 +24,16 @@ Supported ranges: today, yesterday, week, lastweek, month, lastmonth, year, last
   coinw list 2026-04-01..2026-04-30`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var start, end time.Time
+		hasRange := len(args) == 1
+		if hasRange {
+			var err error
+			start, end, err = daterange.Resolve(args[0], time.Now())
+			if err != nil {
+				return err
+			}
+		}
+
 		transactions, err := repo.LoadTransactions()
 		if err != nil {
 			return err
@@ -37,12 +47,7 @@ Supported ranges: today, yesterday, week, lastweek, month, lastmonth, year, last
 		items := make([]model.Transaction, len(transactions))
 		copy(items, transactions)
 
-		if len(args) == 1 {
-			start, end, err := daterange.Resolve(args[0], time.Now())
-			if err != nil {
-				return err
-			}
-
+		if hasRange {
 			filtered := make([]model.Transaction, 0, len(items))
 			for _, tx := range items {
 				inRange, err := daterange.Contains(tx.Date, start, end)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,11 @@ var rootCmd = &cobra.Command{
 	Use:     "coinw",
 	Short:   "Coinwarrior CLI",
 	Version: version,
+	// main already prints the error, so silence cobra's duplicate error line; also
+	// suppress the usage dump on failure so the message isn't buried in a help wall
+	// (users reach usage via --help).
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func Execute() error {

--- a/main.go
+++ b/main.go
@@ -1,13 +1,15 @@
 package main
 
 import (
-	"log"
+	"fmt"
+	"os"
 
 	"github.com/amiraminb/coinwarrior/cmd"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

Two small fixes to how the CLI reports failures.

- **Single, clean error line** — `main` now prints `Error: <err>` to stderr once and exits 1. Previously `log.Fatal` prepended a date/time stamp (making a user error look like a crash) and reprinted the message cobra had already emitted.
- **No duplicate / no usage wall** — `rootCmd` sets `SilenceErrors` and `SilenceUsage`, so cobra neither double-prints the error nor dumps full usage on a runtime failure. Users still reach usage via `--help`.
- **Fail fast on a bad range** — `list` now resolves and validates the range argument *before* the empty-ledger short-circuit. `coinw list notarange` now errors with exit 1 instead of silently printing `no transactions` with exit 0. This matches how `report` already orders validation.

## Why this approach

- `fmt.Fprintln(os.Stderr, "Error:", err)` + `os.Exit(1)` is the idiomatic CLI entrypoint pattern and reproduces cobra's own `Error:` prefix, so output is unchanged except for dropping the misleading timestamp.
- `SilenceUsage` suppresses the usage dump on *all* errors, including arg-validation errors. That is the deliberate trade-off: a failed command shouldn't bury its message under a help wall. The error message itself is always preserved, and `--help` remains the discovery path.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt` all clean.
- Verified against the built binary:
  - `coinw list notarange` (empty ledger) → `Error: invalid range 'notarange'`, exit 1
  - `coinw list month` (empty ledger) → `no transactions`, exit 0
  - `coinw boguscmd` → `Error: unknown command "boguscmd" for "coinw"` (clean, no timestamp)