### PR TITLE
Add CI workflow, fix go.mod version, and format all sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, build and test
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+
+      - name: Check formatting
+        run: |
+            # Scope to tracked source only; gofmt (unlike go vet/build) does not
+            # skip vendor/, so a dumb `gofmt -l .` would fail on third-party code.
+            unformatted=$(gofmt -l $(git ls-files '*.go'))
+            if [[ -n "$unformatted" ]]; then
+                echo "These files are not gofmt-clean:"
+                echo "$unformatted"
+                exit 1
+            fi
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -152,4 +152,3 @@ func setupInitialAccounts(repo repository.Repository) error {
 
 	return nil
 }
-

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/amiraminb/coinwarrior
 
-go 1.25.1
+go 1.25
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0

--- a/internal/repository/accounts.go
+++ b/internal/repository/accounts.go
@@ -3,7 +3,7 @@ package repository
 import "github.com/amiraminb/coinwarrior/internal/model"
 
 type accountsDocument struct {
-	SchemaVersion int              `json:"schema_version"`
+	SchemaVersion int             `json:"schema_version"`
 	Accounts      []model.Account `json:"accounts"`
 }
 

--- a/internal/repository/budgets.go
+++ b/internal/repository/budgets.go
@@ -3,7 +3,7 @@ package repository
 import "github.com/amiraminb/coinwarrior/internal/model"
 
 type budgetsDocument struct {
-	SchemaVersion int             `json:"schema_version"`
+	SchemaVersion int            `json:"schema_version"`
 	Budgets       []model.Budget `json:"budgets"`
 }
 

--- a/internal/repository/transactions.go
+++ b/internal/repository/transactions.go
@@ -3,7 +3,7 @@ package repository
 import "github.com/amiraminb/coinwarrior/internal/model"
 
 type transactionsDocument struct {
-	SchemaVersion int                  `json:"schema_version"`
+	SchemaVersion int                 `json:"schema_version"`
 	Transactions  []model.Transaction `json:"transactions"`
 }
 

--- a/internal/service/categories.go
+++ b/internal/service/categories.go
@@ -34,4 +34,3 @@ func (s *Service) AddCategory(category string) error {
 	categories = append(categories, clean)
 	return s.repo.SaveCategories(categories)
 }
-

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -332,4 +332,3 @@ func cloneAccounts(accounts []model.Account) []model.Account {
 func (e TransactionEdits) empty() bool {
 	return e.Date == nil && e.Amount == nil && e.Category == nil && e.Account == nil && e.ToAccount == nil && e.Note == nil
 }
-

--- a/internal/tui/budget.go
+++ b/internal/tui/budget.go
@@ -336,4 +336,3 @@ func runBudgetShow(monthInput string) error {
 
 	return nil
 }
-

--- a/internal/tui/recurring.go
+++ b/internal/tui/recurring.go
@@ -137,24 +137,24 @@ const (
 )
 
 type recurringFormModel struct {
-	step              recurringField
-	typeChoices       []string
-	typeCursor        int
-	amountInput       string
-	currencyInput     string
-	categories        []string
-	categoryCursor    int
-	accounts          []string
-	accountCursor     int
-	toAccountCursor   int
-	dayInput          string
-	startInput        string
-	endInput          string
-	noteInput         string
-	confirmCursor     int
-	confirmed         bool
-	errMessage        string
-	editingID         string // empty for add
+	step            recurringField
+	typeChoices     []string
+	typeCursor      int
+	amountInput     string
+	currencyInput   string
+	categories      []string
+	categoryCursor  int
+	accounts        []string
+	accountCursor   int
+	toAccountCursor int
+	dayInput        string
+	startInput      string
+	endInput        string
+	noteInput       string
+	confirmCursor   int
+	confirmed       bool
+	errMessage      string
+	editingID       string // empty for add
 }
 
 func newRecurringAddFormModel(categories, accounts []string) recurringFormModel {


### PR DESCRIPTION
## Summary

Tooling hygiene: establish a CI gate, fix a toolchain pin that broke local builds, and bring every source file to `gofmt` standard.

- **CI workflow** (`.github/workflows/ci.yml`) — runs `gofmt` check, `go vet`, `go build`, and `go test` on pushes to `main` and on every PR. Concurrency-guarded (cancels superseded runs), least-privilege (`contents: read`), and manually dispatchable. Nothing previously gated broken or unformatted code on PRs; only a release workflow existed.
- **`go.mod`** — `go 1.25.1` → `go 1.25`. The `go` directive takes a *minimum language version*, not an exact toolchain. The patch pin broke `goenv` (which demanded that exact patch) and disagreed with the release workflow's `go-version: "1.25"`.
- **gofmt sweep** — formatted the 8 files that were not `gofmt`-clean. Whitespace and struct-field alignment only; verified to contain no logic changes (the whitespace-ignored diff shows only trailing-blank-line removals).

## Why this approach

- The gofmt check scopes to tracked source via `gofmt -l $(git ls-files '*.go')` rather than `gofmt -l .`. Unlike `go vet`/`build`/`test`, `gofmt` is a plain file walker and does **not** skip `vendor/`. `vendor/` is gitignored today so a bare `.` would be fine now, but scoping to first-party files removes a latent footgun if `vendor/` is ever committed or generated in CI.
- Runner is pinned to `ubuntu-24.04` (not `ubuntu-latest`) and official actions use the same `@v4`/`@v5` semver style as the sibling `release.yml`.

## Testing

- All four CI steps run clean locally: `gofmt` (no output), `go vet ./...`, `go build ./...`, `go test ./...` (exits 0; `[no test files]` is success).
- `ci.yml` validated with `actionlint` (passes, shellcheck-clean).
- Confirmed `go build` works with the default `goenv` toolchain after the `go.mod` fix (it failed before, demanding the missing `1.25.1`).

## Note

`go test` currently has no tests to run — the test suite lands in a later PR. This PR puts the gate in place first so that suite is enforced the moment it arrives.