### PR TITLE
13/Only quit on "q" at menu steps, not text inputs

### DIFF
--- a/internal/daterange/daterange_test.go
+++ b/internal/daterange/daterange_test.go
@@ -1,0 +1,175 @@
+package daterange
+
+import (
+	"testing"
+	"time"
+)
+
+func mustDay(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.ParseInLocation("2006-01-02", value, time.UTC)
+	if err != nil {
+		t.Fatalf("mustDay(%q): %v", value, err)
+	}
+	return parsed
+}
+
+// Wednesday, with a time component to confirm Resolve normalizes to whole days.
+var resolveNow = time.Date(2026, 3, 18, 14, 30, 0, 0, time.UTC)
+
+// A January reference date for exercising year-boundary rollover.
+var janNow = time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+
+func TestResolveKeywords(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		now   time.Time
+		start string
+		end   string
+	}{
+		{"today", "today", resolveNow, "2026-03-18", "2026-03-18"},
+		{"yesterday", "yesterday", resolveNow, "2026-03-17", "2026-03-17"},
+		// Week starts Monday; 2026-03-18 is a Wednesday.
+		{"week", "week", resolveNow, "2026-03-16", "2026-03-22"},
+		{"lastweek", "lastweek", resolveNow, "2026-03-09", "2026-03-15"},
+		{"month", "month", resolveNow, "2026-03-01", "2026-03-31"},
+		{"lastmonth", "lastmonth", resolveNow, "2026-02-01", "2026-02-28"},
+		{"year", "year", resolveNow, "2026-01-01", "2026-12-31"},
+		{"lastyear", "lastyear", resolveNow, "2025-01-01", "2025-12-31"},
+		{"explicit range", "2026-04-01..2026-04-30", resolveNow, "2026-04-01", "2026-04-30"},
+		{"uppercase keyword", "TODAY", resolveNow, "2026-03-18", "2026-03-18"},
+		// January now() exercises the year rollover in lastmonth / lastyear.
+		{"lastmonth crosses year", "lastmonth", janNow, "2025-12-01", "2025-12-31"},
+		{"lastyear from january", "lastyear", janNow, "2025-01-01", "2025-12-31"},
+		{"month in january", "month", janNow, "2026-01-01", "2026-01-31"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, err := Resolve(tc.input, tc.now)
+			if err != nil {
+				t.Fatalf("Resolve(%q): %v", tc.input, err)
+			}
+			if !start.Equal(mustDay(t, tc.start)) {
+				t.Errorf("Resolve(%q) start = %s, want %s", tc.input, start.Format("2006-01-02"), tc.start)
+			}
+			if !end.Equal(mustDay(t, tc.end)) {
+				t.Errorf("Resolve(%q) end = %s, want %s", tc.input, end.Format("2006-01-02"), tc.end)
+			}
+		})
+	}
+}
+
+func TestResolveErrors(t *testing.T) {
+	inputs := []string{
+		"",
+		"   ",
+		"notarange",
+		"2026-04-01..2026-04-02..2026-04-03",
+		"bad..2026-04-30",
+		"2026-04-01..bad",
+		"2026-04-30..2026-04-01", // end before start
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			if _, _, err := Resolve(input, resolveNow); err == nil {
+				t.Errorf("Resolve(%q) = nil error, want error", input)
+			}
+		})
+	}
+}
+
+func TestMonthBounds(t *testing.T) {
+	tests := []struct {
+		name  string
+		month time.Time
+		start string
+		end   string
+	}{
+		{"31-day month", time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC), "2026-03-01", "2026-03-31"},
+		{"february non-leap", time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC), "2026-02-01", "2026-02-28"},
+		{"february leap year", time.Date(2024, 2, 10, 0, 0, 0, 0, time.UTC), "2024-02-01", "2024-02-29"},
+		{"december", time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC), "2026-12-01", "2026-12-31"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end := MonthBounds(tc.month)
+			if !start.Equal(mustDay(t, tc.start)) {
+				t.Errorf("MonthBounds start = %s, want %s", start.Format("2006-01-02"), tc.start)
+			}
+			if !end.Equal(mustDay(t, tc.end)) {
+				t.Errorf("MonthBounds end = %s, want %s", end.Format("2006-01-02"), tc.end)
+			}
+		})
+	}
+}
+
+func TestParseMonth(t *testing.T) {
+	now := time.Date(2026, 3, 18, 0, 0, 0, 0, time.UTC)
+
+	got, err := ParseMonth("2026-07", now)
+	if err != nil {
+		t.Fatalf("ParseMonth: %v", err)
+	}
+	if !got.Equal(mustDay(t, "2026-07-01")) {
+		t.Errorf("ParseMonth(\"2026-07\") = %s, want 2026-07-01", got.Format("2006-01-02"))
+	}
+
+	got, err = ParseMonth("", now)
+	if err != nil {
+		t.Fatalf("ParseMonth(empty): %v", err)
+	}
+	if !got.Equal(mustDay(t, "2026-03-01")) {
+		t.Errorf("ParseMonth(\"\") = %s, want 2026-03-01 (current month)", got.Format("2006-01-02"))
+	}
+
+	if _, err := ParseMonth("2026-13", now); err == nil {
+		t.Error("ParseMonth(\"2026-13\") = nil error, want error")
+	}
+	if _, err := ParseMonth("not-a-month", now); err == nil {
+		t.Error("ParseMonth(\"not-a-month\") = nil error, want error")
+	}
+}
+
+func TestContains(t *testing.T) {
+	start := mustDay(t, "2026-03-01")
+	end := mustDay(t, "2026-03-31")
+
+	tests := []struct {
+		date string
+		want bool
+	}{
+		{"2026-03-01", true},  // inclusive lower bound
+		{"2026-03-31", true},  // inclusive upper bound
+		{"2026-03-15", true},  // interior
+		{"2026-02-28", false}, // before
+		{"2026-04-01", false}, // after
+	}
+	for _, tc := range tests {
+		t.Run(tc.date, func(t *testing.T) {
+			got, err := Contains(tc.date, start, end)
+			if err != nil {
+				t.Fatalf("Contains(%q): %v", tc.date, err)
+			}
+			if got != tc.want {
+				t.Errorf("Contains(%q) = %t, want %t", tc.date, got, tc.want)
+			}
+		})
+	}
+
+	if _, err := Contains("not-a-date", start, end); err == nil {
+		t.Error("Contains(\"not-a-date\") = nil error, want error")
+	}
+}
+
+func TestDateOnly(t *testing.T) {
+	withTime := time.Date(2026, 3, 18, 14, 30, 45, 123, time.UTC)
+	got := DateOnly(withTime)
+	want := mustDay(t, "2026-03-18")
+	if !got.Equal(want) {
+		t.Errorf("DateOnly = %s, want %s", got, want)
+	}
+	if got.Hour() != 0 || got.Minute() != 0 || got.Second() != 0 || got.Nanosecond() != 0 {
+		t.Errorf("DateOnly did not zero the time component: %s", got)
+	}
+}

--- a/internal/money/money.go
+++ b/internal/money/money.go
@@ -2,6 +2,7 @@ package money
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -28,33 +29,50 @@ func Parse(input string) (int64, error) {
 		return 0, fmt.Errorf("invalid amount format: %s", input)
 	}
 
-	whole := parts[0]
+	// Accept thousands separators in the whole-number part so values copied from
+	// formatted output (e.g. "1,234.50") round-trip through Parse. Commas in the
+	// fractional part remain invalid.
+	wholePart := strings.ReplaceAll(parts[0], ",", "")
+	fracPart := ""
+	if len(parts) == 2 {
+		fracPart = parts[1]
+	}
+
+	// Each part must be digits only (an empty part is allowed, e.g. ".5" or "5."),
+	// and at least one digit must be present. This rejects forms like "." or "--5"
+	// that strconv would otherwise read as a silent zero or a flipped sign.
+	if !isDigits(wholePart) || !isDigits(fracPart) {
+		return 0, fmt.Errorf("invalid amount: %s", input)
+	}
+	if wholePart == "" && fracPart == "" {
+		return 0, fmt.Errorf("invalid amount: %s", input)
+	}
+	if len(fracPart) > 2 {
+		return 0, fmt.Errorf("amount supports max 2 decimals: %s", input)
+	}
+
+	whole := wholePart
 	if whole == "" {
 		whole = "0"
 	}
-
 	wholeValue, err := strconv.ParseInt(whole, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid amount: %s", input)
 	}
 
-	frac := "00"
-	if len(parts) == 2 {
-		if len(parts[1]) > 2 {
-			return 0, fmt.Errorf("amount supports max 2 decimals: %s", input)
-		}
-		frac = parts[1]
-		if len(frac) == 1 {
-			frac += "0"
-		}
-		if len(frac) == 0 {
-			frac = "00"
-		}
+	frac := fracPart
+	for len(frac) < 2 {
+		frac += "0"
 	}
-
 	fracValue, err := strconv.ParseInt(frac, 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("invalid amount: %s", input)
+	}
+
+	// Guard before computing wholeValue*100+fracValue, which would otherwise
+	// silently wrap past int64 into a negative balance.
+	if wholeValue > (math.MaxInt64-fracValue)/100 {
+		return 0, fmt.Errorf("amount is too large: %s", input)
 	}
 
 	result := wholeValue*100 + fracValue
@@ -63,6 +81,15 @@ func Parse(input string) (int64, error) {
 	}
 
 	return result, nil
+}
+
+func isDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func Format(amountMinor int64) string {

--- a/internal/money/money_test.go
+++ b/internal/money/money_test.go
@@ -1,0 +1,108 @@
+package money
+
+import (
+	"math"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  int64
+	}{
+		{"whole number", "5", 500},
+		{"zero", "0", 0},
+		{"one decimal", "5.5", 550},
+		{"two decimals", "5.50", 550},
+		{"leading decimal", ".5", 50},
+		{"trailing decimal point", "5.", 500},
+		{"negative", "-5", -500},
+		{"negative with decimals", "-5.25", -525},
+		{"negative leading decimal", "-.5", -50},
+		{"surrounding whitespace", "  12.34  ", 1234},
+		{"whitespace after sign", "- 5", -500},
+		{"thousands separator", "1,234.50", 123450},
+		{"multiple thousands separators", "1,234,567", 123456700},
+		{"max int64 boundary", "92233720368547758.07", math.MaxInt64},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Parse(tc.input)
+			if err != nil {
+				t.Fatalf("Parse(%q) returned error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("Parse(%q) = %d, want %d", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"bare minus", "-"},
+		{"lone decimal point", "."},
+		{"double minus", "--5"},
+		{"non-numeric", "abc"},
+		{"trailing letters", "5abc"},
+		{"three decimals", "5.555"},
+		{"two decimal points", "5.5.5"},
+		{"comma in fractional part", "1.2,3"},
+		{"overflow", "100000000000000000"},
+		{"just over max int64", "92233720368547758.08"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := Parse(tc.input); err == nil {
+				t.Errorf("Parse(%q) = %d, want error", tc.input, got)
+			}
+		})
+	}
+}
+
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		name  string
+		input int64
+		want  string
+	}{
+		{"zero", 0, "0.00"},
+		{"under a dollar", 50, "0.50"},
+		{"single digit fraction", 5, "0.05"},
+		{"whole dollars", 500, "5.00"},
+		{"with fraction", 1234, "12.34"},
+		{"thousands", 123450, "1,234.50"},
+		{"millions", 123456789, "1,234,567.89"},
+		{"negative", -525, "-5.25"},
+		{"negative thousands", -123450, "-1,234.50"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Format(tc.input); got != tc.want {
+				t.Errorf("Format(%d) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// Format must produce a string that Parse reads back to the same value, so
+// amounts copied from displayed output are accepted verbatim.
+func TestParseFormatRoundTrip(t *testing.T) {
+	values := []int64{0, 5, 50, 500, 1234, 123450, 123456789, -525, -123450, math.MaxInt64}
+	for _, v := range values {
+		formatted := Format(v)
+		got, err := Parse(formatted)
+		if err != nil {
+			t.Fatalf("Parse(Format(%d)) = Parse(%q) returned error: %v", v, formatted, err)
+		}
+		if got != v {
+			t.Errorf("round trip for %d: Format = %q, Parse = %d", v, formatted, got)
+		}
+	}
+}

--- a/internal/tui/account.go
+++ b/internal/tui/account.go
@@ -82,8 +82,9 @@ func (m accountUpdateModel) Init() tea.Cmd {
 func (m accountAddModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch msg.String() {
-		case "ctrl+c", "q":
+		// Every accountAddModel step is free-text entry, so only ctrl+c quits;
+		// "q" must be typeable into the name/currency fields.
+		if msg.String() == "ctrl+c" {
 			return m, tea.Quit
 		}
 
@@ -147,12 +148,23 @@ func (m accountAddModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// isSelectionStep reports whether the step is a menu (account list or Yes/No
+// confirm) rather than free-text entry. On menu steps a bare "q" quits; on the
+// amount step it must be typed into the field.
+func (s accountUpdateStep) isSelectionStep() bool {
+	return s == accountUpdateStepSelect || s == accountUpdateStepConfirm
+}
+
 func (m accountUpdateModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c":
 			return m, tea.Quit
+		case "q":
+			if m.step.isSelectionStep() {
+				return m, tea.Quit
+			}
 		}
 
 		switch m.step {
@@ -248,7 +260,7 @@ func (m accountAddModel) View() string {
 		s += renderField("Opening balance: ", m.openingBalanceInput) + "\n\n"
 	}
 
-	s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+	s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 
 	return s
 }
@@ -275,7 +287,7 @@ func (m accountUpdateModel) View() string {
 		if m.errMessage != "" {
 			s += warnStyle.Render(m.errMessage) + "\n"
 		}
-		s += "\n" + mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += "\n" + mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case accountUpdateStepConfirm:
 		newBalanceMinor, _ := money.Parse(m.amountInput)
 		s += renderField("Account: ", m.selectedAccount.Name) + "\n"

--- a/internal/tui/add.go
+++ b/internal/tui/add.go
@@ -79,12 +79,30 @@ func (m addModel) Init() tea.Cmd {
 	return nil
 }
 
+// isSelectionStep reports whether the step is a menu (list selection or Yes/No
+// confirm) rather than free-text entry. On menu steps a bare "q" quits; on
+// text steps it must be typed into the field, so the global handler lets it
+// fall through.
+func (s addStep) isSelectionStep() bool {
+	switch s {
+	case stepType, stepCategorySelect, stepCategoryConfirm,
+		stepAccountSelect, stepAccountConfirm, stepTransferToAccountSelect:
+		return true
+	default:
+		return false
+	}
+}
+
 func (m addModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c":
 			return m, tea.Quit
+		case "q":
+			if m.step.isSelectionStep() {
+				return m, tea.Quit
+			}
 		}
 		switch m.step {
 		case stepType:
@@ -362,17 +380,17 @@ func (m addModel) View() string {
 	case stepAmount:
 		s += renderField("Type selected: ", m.selected) + "\n\n"
 		s += renderActiveField("Enter amount: ", m.amountInput) + "\n"
-		s += mutedStyle.Render("(press enter to continue, q to quit)") + "\n"
+		s += mutedStyle.Render("(press enter to continue, ctrl+c to quit)") + "\n"
 	case stepDate:
 		s += renderField("Type selected: ", m.selected) + "\n"
 		s += renderField("Amount: ", m.amountInput) + "\n\n"
 		s += renderActiveField("Enter date (YYYY-MM-DD): ", m.dateInput) + "\n"
-		s += mutedStyle.Render("(press enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(press enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case stepCurrency:
 		s += renderField("Type selected: ", m.selected) + "\n"
 		s += renderField("Amount: ", m.amountInput) + "\n\n"
 		s += renderActiveField("Enter currency: ", m.currencyInput) + "\n"
-		s += mutedStyle.Render("(press enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(press enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case stepCategorySelect:
 		s += renderField("Type selected: ", m.selected) + "\n"
 		s += renderField("Amount: ", m.amountInput) + "\n"
@@ -396,7 +414,7 @@ func (m addModel) View() string {
 		s += renderField("Amount: ", m.amountInput) + "\n"
 		s += renderField("Currency: ", m.currencyInput) + "\n\n"
 		s += renderActiveField("Enter category: ", m.categoryDraft) + "\n"
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case stepCategoryConfirm:
 		s += renderField("Type selected: ", m.selected) + "\n"
 		s += renderField("Amount: ", m.amountInput) + "\n"
@@ -445,7 +463,7 @@ func (m addModel) View() string {
 		s += renderField("Currency: ", m.currencyInput) + "\n"
 		s += renderField("Category: ", m.categoryInput) + "\n\n"
 		s += renderActiveField("Enter account: ", m.accountDraft) + "\n"
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case stepTransferToAccountSelect:
 		s += renderField("Type selected: ", m.selected) + "\n"
 		s += renderField("Amount: ", m.amountInput) + "\n"
@@ -498,7 +516,7 @@ func (m addModel) View() string {
 			s += renderField("Category: ", model.TransferCategory) + "\n\n"
 		}
 		s += renderActiveField("Enter note (optional): ", m.noteInput) + "\n"
-		s += mutedStyle.Render("(enter to save, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to save, esc to go back, ctrl+c to quit)") + "\n"
 	case stepDone:
 		s += mutedStyle.Render("Done") + "\n"
 	}

--- a/internal/tui/budget.go
+++ b/internal/tui/budget.go
@@ -53,12 +53,23 @@ func (m budgetSetModel) Init() tea.Cmd {
 	return nil
 }
 
+// isSelectionStep reports whether the step is a menu (Yes/No confirm) rather
+// than free-text entry. On menu steps a bare "q" quits; on text steps it must
+// be typed into the field, so the global handler lets it fall through.
+func (s budgetSetStep) isSelectionStep() bool {
+	return s == budgetSetStepConfirm
+}
+
 func (m budgetSetModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c":
 			return m, tea.Quit
+		case "q":
+			if m.step.isSelectionStep() {
+				return m, tea.Quit
+			}
 		}
 
 		switch m.step {
@@ -170,18 +181,18 @@ func (m budgetSetModel) View() string {
 	case budgetSetStepMonth:
 		s += renderActiveField("Month (YYYY-MM): ", m.monthInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, ctrl+c to quit)") + "\n"
 	case budgetSetStepCurrency:
 		s += renderField("Month: ", m.monthInput) + "\n\n"
 		s += renderActiveField("Currency: ", m.currencyInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case budgetSetStepAmount:
 		s += renderField("Month: ", m.monthInput) + "\n"
 		s += renderField("Currency: ", strings.ToUpper(strings.TrimSpace(m.currencyInput))) + "\n\n"
 		s += renderActiveField("Budget amount: ", m.amountInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case budgetSetStepConfirm:
 		s += renderField("Month: ", m.monthInput) + "\n"
 		s += renderField("Currency: ", strings.ToUpper(strings.TrimSpace(m.currencyInput))) + "\n"

--- a/internal/tui/edit.go
+++ b/internal/tui/edit.go
@@ -59,12 +59,23 @@ func (m editModel) Init() tea.Cmd {
 	return nil
 }
 
+// isSelectionStep reports whether the step is a menu (Yes/No confirm) rather
+// than free-text entry. On menu steps a bare "q" quits; on text steps it must
+// be typed into the field, so the global handler lets it fall through.
+func (s editStep) isSelectionStep() bool {
+	return s == editStepConfirm
+}
+
 func (m editModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c":
 			return m, tea.Quit
+		case "q":
+			if m.step.isSelectionStep() {
+				return m, tea.Quit
+			}
 		}
 
 		switch m.step {
@@ -254,19 +265,19 @@ func (m editModel) View() string {
 		s += renderField("Type: ", m.selected.Type) + "\n\n"
 		s += renderActiveField("Date: ", m.dateInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to cancel, ctrl+c to quit)") + "\n"
 	case editStepAmount:
 		s += renderField("Editing: ", m.selected.ID) + "\n"
 		s += renderField("Date: ", m.dateInput) + "\n\n"
 		s += renderActiveField("Amount: ", m.amountInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case editStepCategory:
 		s += renderField("Editing: ", m.selected.ID) + "\n"
 		s += renderField("Date: ", m.dateInput) + "\n"
 		s += renderField("Amount: ", m.amountInput) + "\n\n"
 		s += renderActiveField("Category: ", m.categoryInput) + "\n"
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case editStepAccount:
 		s += renderField("Editing: ", m.selected.ID) + "\n"
 		s += renderField("Date: ", m.dateInput) + "\n"
@@ -274,7 +285,7 @@ func (m editModel) View() string {
 		s += renderField("Category: ", m.categoryInput) + "\n\n"
 		s += renderActiveField("Account: ", m.accountInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case editStepToAccount:
 		s += renderField("Editing: ", m.selected.ID) + "\n"
 		s += renderField("Date: ", m.dateInput) + "\n"
@@ -283,7 +294,7 @@ func (m editModel) View() string {
 		s += renderField("From account: ", m.accountInput) + "\n\n"
 		s += renderActiveField("To account: ", m.toAccountInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case editStepNote:
 		s += renderField("Editing: ", m.selected.ID) + "\n"
 		s += renderField("Date: ", m.dateInput) + "\n"
@@ -294,7 +305,7 @@ func (m editModel) View() string {
 			s += renderField("To account: ", m.toAccountInput) + "\n"
 		}
 		s += "\n" + renderActiveField("Note: ", m.noteInput) + "\n"
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case editStepConfirm:
 		s += renderField("Editing: ", m.selected.ID) + "\n"
 		s += renderField("Date: ", m.dateInput) + "\n"

--- a/internal/tui/quit_test.go
+++ b/internal/tui/quit_test.go
@@ -1,0 +1,221 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/amiraminb/coinwarrior/internal/model"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func keyRunes(s string) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+}
+
+// quits reports whether a command, when run, yields a tea.QuitMsg.
+func quits(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+	_, ok := cmd().(tea.QuitMsg)
+	return ok
+}
+
+// On text-entry steps, "q" must be typed into the field rather than quitting.
+// On menu steps (list selection, Yes/No confirm) it stays a quit shortcut.
+// ctrl+c always quits. This is the regression guard for issue #13.
+
+func TestAddModelQuitOnlyOnSelectionSteps(t *testing.T) {
+	for _, step := range []addStep{
+		stepType, stepCategorySelect, stepCategoryConfirm,
+		stepAccountSelect, stepAccountConfirm, stepTransferToAccountSelect,
+	} {
+		if !step.isSelectionStep() {
+			t.Errorf("step %d should be a selection step", step)
+		}
+		m := newAddModel(nil, nil)
+		m.step = step
+		if _, cmd := m.Update(keyRunes("q")); !quits(cmd) {
+			t.Errorf("q on selection step %d should quit", step)
+		}
+	}
+
+	// All text steps must not quit on "q" (the core of issue #13).
+	for _, step := range []addStep{stepAmount, stepDate, stepCurrency, stepCategoryInput, stepAccountInput, stepNote} {
+		if step.isSelectionStep() {
+			t.Errorf("step %d should be a text step", step)
+		}
+		m := newAddModel(nil, nil)
+		m.step = step
+		if _, cmd := m.Update(keyRunes("q")); quits(cmd) {
+			t.Errorf("q on text step %d should not quit", step)
+		}
+	}
+
+	// On free-text fields that accept letters, "q" is captured as a character.
+	capture := []struct {
+		step  addStep
+		field func(addModel) string
+	}{
+		{stepCurrency, func(m addModel) string { return m.currencyInput }},
+		{stepCategoryInput, func(m addModel) string { return m.categoryDraft }},
+		{stepAccountInput, func(m addModel) string { return m.accountDraft }},
+		{stepNote, func(m addModel) string { return m.noteInput }},
+	}
+	for _, c := range capture {
+		m := newAddModel(nil, nil)
+		m.step = c.step
+		m.currencyInput = "" // cleared so the 3-char currency cap doesn't reject "q"
+		next, _ := m.Update(keyRunes("q"))
+		// Currency uppercases input; the others keep it as-is.
+		got := c.field(next.(addModel))
+		if got != "q" && got != "Q" {
+			t.Errorf("q on text step %d was not typed into the field (got %q)", c.step, got)
+		}
+	}
+
+	m := newAddModel(nil, nil)
+	m.step = stepNote
+	if _, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC}); !quits(cmd) {
+		t.Error("ctrl+c on a text step should quit")
+	}
+}
+
+func TestEditModelQuitOnlyOnConfirm(t *testing.T) {
+	tx := model.Transaction{ID: "txn_1", Type: model.TransactionTypeExpense, Date: "2026-03-01"}
+
+	m := newEditModel(tx)
+	m.step = editStepConfirm
+	if _, cmd := m.Update(keyRunes("q")); !quits(cmd) {
+		t.Error("q on edit confirm step should quit")
+	}
+
+	// editStepDate and editStepAmount are numeric/date text steps: "q" is not a
+	// valid character there, so it is dropped, but it must still never quit.
+	for _, step := range []editStep{editStepDate, editStepAmount, editStepToAccount} {
+		m := newEditModel(tx)
+		m.step = step
+		if _, cmd := m.Update(keyRunes("q")); quits(cmd) {
+			t.Errorf("q on edit text step %d should not quit", step)
+		}
+	}
+
+	for _, step := range []editStep{editStepCategory, editStepAccount, editStepNote} {
+		m := newEditModel(tx)
+		m.step = step
+		next, cmd := m.Update(keyRunes("q"))
+		if quits(cmd) {
+			t.Errorf("q on edit text step %d should not quit", step)
+		}
+		got := next.(editModel)
+		field := map[editStep]string{
+			editStepCategory: got.categoryInput,
+			editStepAccount:  got.accountInput,
+			editStepNote:     got.noteInput,
+		}[step]
+		if field != "q" {
+			t.Errorf("q on edit text step %d was not typed (field=%q)", step, field)
+		}
+	}
+}
+
+func TestAccountAddModelNeverQuitsOnQ(t *testing.T) {
+	m := newAccountAddModel()
+	m.step = accountStepName
+	next, cmd := m.Update(keyRunes("q"))
+	if quits(cmd) {
+		t.Error("q on account name step should not quit")
+	}
+	if next.(accountAddModel).nameInput != "q" {
+		t.Error("q should be typed into the account name field")
+	}
+
+	fresh := newAccountAddModel()
+	if _, cmd := fresh.Update(tea.KeyMsg{Type: tea.KeyCtrlC}); !quits(cmd) {
+		t.Error("ctrl+c on account add should quit")
+	}
+}
+
+func TestAccountUpdateModelQuitMatrix(t *testing.T) {
+	accounts := []model.Account{{Name: "Checking", Currency: "CAD"}}
+
+	m := newAccountUpdateModel(accounts)
+	m.step = accountUpdateStepSelect
+	if _, cmd := m.Update(keyRunes("q")); !quits(cmd) {
+		t.Error("q on account select step should quit")
+	}
+
+	m = newAccountUpdateModel(accounts)
+	m.step = accountUpdateStepAmount
+	next, cmd := m.Update(keyRunes("q"))
+	if quits(cmd) {
+		t.Error("q on account update amount step should not quit")
+	}
+	if next.(accountUpdateModel).amountInput != "" {
+		t.Error("q (non-numeric) should be ignored by amount field, not quit")
+	}
+}
+
+func TestRecurringFormModelQuitMatrix(t *testing.T) {
+	accounts := []string{"Checking", "Savings"}
+	categories := []string{"Rent", "Groceries"}
+
+	for _, step := range []recurringField{
+		recurringFieldType, recurringFieldCategory, recurringFieldAccount,
+		recurringFieldToAccount, recurringFieldConfirm,
+	} {
+		if !step.isSelectionStep() {
+			t.Errorf("recurring step %d should be a selection step", step)
+		}
+		m := newRecurringAddFormModel(categories, accounts)
+		m.step = step
+		if _, cmd := m.Update(keyRunes("q")); !quits(cmd) {
+			t.Errorf("q on recurring selection step %d should quit", step)
+		}
+	}
+
+	for _, step := range []recurringField{
+		recurringFieldAmount, recurringFieldCurrency, recurringFieldDayOfMonth,
+		recurringFieldStartDate, recurringFieldEndDate, recurringFieldNote,
+	} {
+		if step.isSelectionStep() {
+			t.Errorf("recurring step %d should be a text step", step)
+		}
+		m := newRecurringAddFormModel(categories, accounts)
+		m.step = step
+		if _, cmd := m.Update(keyRunes("q")); quits(cmd) {
+			t.Errorf("q on recurring text step %d should not quit", step)
+		}
+	}
+
+	// "q" is typed into a free-text field (note), and ctrl+c quits from a menu.
+	m := newRecurringAddFormModel(categories, accounts)
+	m.step = recurringFieldNote
+	next, _ := m.Update(keyRunes("q"))
+	if next.(recurringFormModel).noteInput != "q" {
+		t.Error("q should be typed into the recurring note field")
+	}
+
+	m = newRecurringAddFormModel(categories, accounts)
+	m.step = recurringFieldType
+	if _, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC}); !quits(cmd) {
+		t.Error("ctrl+c on a recurring menu step should quit")
+	}
+}
+
+func TestBudgetSetModelQuitMatrix(t *testing.T) {
+	m := newBudgetSetModel()
+	m.step = budgetSetStepConfirm
+	if _, cmd := m.Update(keyRunes("q")); !quits(cmd) {
+		t.Error("q on budget confirm step should quit")
+	}
+
+	m = newBudgetSetModel()
+	m.step = budgetSetStepCurrency
+	next, cmd := m.Update(keyRunes("q"))
+	if quits(cmd) {
+		t.Error("q on budget currency step should not quit")
+	}
+	if next.(budgetSetModel).currencyInput != "CADQ" {
+		t.Errorf("q should be typed (uppercased) into currency field, got %q", next.(budgetSetModel).currencyInput)
+	}
+}

--- a/internal/tui/recurring.go
+++ b/internal/tui/recurring.go
@@ -259,12 +259,29 @@ func formatRuleAmountInput(amountMinor int64) string {
 
 func (m recurringFormModel) Init() tea.Cmd { return nil }
 
+// isSelectionStep reports whether the step is a menu (type/category/account
+// list or Yes/No confirm) rather than free-text entry. On menu steps a bare "q"
+// quits; on text steps it must be typed into the field.
+func (s recurringField) isSelectionStep() bool {
+	switch s {
+	case recurringFieldType, recurringFieldCategory, recurringFieldAccount,
+		recurringFieldToAccount, recurringFieldConfirm:
+		return true
+	default:
+		return false
+	}
+}
+
 func (m recurringFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "q":
+		case "ctrl+c":
 			return m, tea.Quit
+		case "q":
+			if m.step.isSelectionStep() {
+				return m, tea.Quit
+			}
 		}
 
 		switch m.step {
@@ -531,13 +548,13 @@ func (m recurringFormModel) View() string {
 		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n\n"
 		s += renderActiveField("Amount: ", m.amountInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case recurringFieldCurrency:
 		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n"
 		s += renderField("Amount: ", m.amountInput) + "\n\n"
 		s += renderActiveField("Currency: ", m.currencyInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case recurringFieldCategory:
 		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n"
 		s += renderField("Amount: ", m.amountInput) + "\n"
@@ -587,20 +604,20 @@ func (m recurringFormModel) View() string {
 		s += renderField("Account: ", m.selectedAccount()) + "\n\n"
 		s += renderActiveField("Day of month (1-28): ", m.dayInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case recurringFieldStartDate:
 		s += renderField("Day of month: ", m.dayInput) + "\n\n"
 		s += renderActiveField("Start date (YYYY-MM-DD): ", m.startInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case recurringFieldEndDate:
 		s += renderField("Start date: ", m.startInput) + "\n\n"
 		s += renderActiveField("End date (YYYY-MM-DD, blank for none): ", m.endInput) + "\n"
 		s += renderError(m.errMessage)
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case recurringFieldNote:
 		s += renderActiveField("Note (optional): ", m.noteInput) + "\n"
-		s += mutedStyle.Render("(enter to continue, esc to go back, q to quit)") + "\n"
+		s += mutedStyle.Render("(enter to continue, esc to go back, ctrl+c to quit)") + "\n"
 	case recurringFieldConfirm:
 		s += renderField("Type: ", m.typeChoices[m.typeCursor]) + "\n"
 		s += renderField("Amount: ", m.amountInput) + " " + m.currencyInput + "\n"


### PR DESCRIPTION
## Summary

Fixes #13. Every interactive form intercepted `q` as a global quit at the top of `Update`, before the per-step handler ran. So typing a note, free-text category, account name, or currency containing the letter `q` (e.g. "quarterly") silently discarded the entire in-progress form.

- `ctrl+c` still quits from **any** step.
- Bare `q` now quits **only on selection steps** (list pickers and Yes/No confirms). On text-entry steps it falls through and is typed into the field.
- Help-text footers updated to match: text steps say `ctrl+c to quit`; menu steps keep `q to quit`.

## Approach

Implemented the issue's recommended **Option B** (q is a navigation-only shortcut). Each model gained a small `isSelectionStep()` method enumerating its menu steps; the global handler quits on `q` only when `m.step.isSelectionStep()`.

- Chosen over Option A (per-step opt-out at every text step) because it's a smaller, centralized change and gives users a consistent rule: `q` quits lists/menus, `ctrl+c` always quits, text fields type normally.
- `accountAddModel` has only text steps, so it simply quits on `ctrl+c` alone (no `isSelectionStep` needed).

## Per-model step classification

| Model | Menu steps (q quits) | Text steps (q typed) |
|-------|----------------------|----------------------|
| add | type, categorySelect, categoryConfirm, accountSelect, accountConfirm, transferToAccount | amount, date, currency, categoryInput, accountInput, note |
| edit | confirm | date, amount, category, account, toAccount, note |
| accountAdd | — (none) | name, currency, openingBalance |
| accountUpdate | select, confirm | amount |
| budget | confirm | month, currency, amount |
| recurring | type, category, account, toAccount, confirm | amount, currency, dayOfMonth, startDate, endDate, note |

## Also

- `editStepDate`'s footer now says `esc to cancel` instead of `esc to go back` — on that first step `esc` quits (there is no previous step to return to), so the old wording was misleading and the `q`→`ctrl+c` change made it more visible.

## Testing

- New `internal/tui/quit_test.go` asserts the full per-step quit matrix across **all six** form models: every menu step quits on `q`, every text step does **not**, `q` is captured into free-text fields, and `ctrl+c` always quits.
- I verified the test genuinely fails against the pre-fix code (all six add-form text steps reported "should not quit") and passes against the fix — a real regression guard.
- `go test ./...`, `go build`, `go vet`, `gofmt` all clean. Binary smoke-tested.