### PR TITLE
Generate the current month's recurring transaction early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Recurring transactions with idempotent monthly generation: `coinw recurring`
-  (list, add, edit, delete rules, and generate due transactions)
+  (list, add, edit, delete rules, and generate due transactions). The current
+  month's occurrence is generated as soon as the month begins, even when the
+  rule's day-of-month is later in the month, and is dated to that scheduled day.
 
 ## [0.1.0] - 2026-05-16
 

--- a/internal/service/recurring.go
+++ b/internal/service/recurring.go
@@ -398,6 +398,12 @@ func applyRecurringRuleEdits(rule model.RecurringRule, edits RecurringRuleEdits,
 	return updated, true, nil
 }
 
+// dueTransactionsForRule returns the transactions a rule is due to generate up
+// to and including the current month. A month's occurrence is generated as soon
+// as that month has begun, even if the rule's day-of-month has not yet arrived
+// (e.g. on 2026-06-01 a rule due on the 28th generates its 2026-06-28
+// transaction now). Occurrences are still bounded by the rule's start and end
+// dates, and future months are never generated.
 func dueTransactionsForRule(rule model.RecurringRule, today, now time.Time, nowUTC string, idCounter *int) ([]model.Transaction, error) {
 	startTime, err := time.Parse("2006-01-02", rule.StartDate)
 	if err != nil {
@@ -429,15 +435,14 @@ func dueTransactionsForRule(rule model.RecurringRule, today, now time.Time, nowU
 	var due []model.Transaction
 	currentMonth := time.Date(today.Year(), today.Month(), 1, 0, 0, 0, 0, today.Location())
 	for !cursor.After(currentMonth) {
+		// DayOfMonth is capped at 1..28, so this never overflows into the next
+		// month. If days 29..31 are ever allowed, clamp to the month's last day
+		// here, since the current month is now materialized eagerly on day 1.
 		txDate := time.Date(cursor.Year(), cursor.Month(), rule.DayOfMonth, 0, 0, 0, 0, today.Location())
-		if txDate.After(today) {
-			break
-		}
 		if endLimit != nil && txDate.After(*endLimit) {
 			break
 		}
-		startBoundary, _ := time.Parse("2006-01-02", rule.StartDate)
-		if txDate.Before(startBoundary) {
+		if txDate.Before(startTime) {
 			cursor = cursor.AddDate(0, 1, 0)
 			continue
 		}

--- a/internal/service/recurring_test.go
+++ b/internal/service/recurring_test.go
@@ -149,3 +149,120 @@ func TestGenerateDueTransactionsRollsBackOnTransactionsSaveFailure(t *testing.T)
 		t.Fatalf("after failed generation: LastGeneratedMonth is %q, want empty (not advanced)", repo.rules[0].LastGeneratedMonth)
 	}
 }
+
+// ruleRepo builds a single-rule repo for current-month generation tests.
+func ruleRepo(rule model.RecurringRule) *fakeRepo {
+	return &fakeRepo{
+		accounts: []model.Account{{Name: "Checking", Currency: "CAD", BalanceMinor: 100000}},
+		rules:    []model.RecurringRule{rule},
+	}
+}
+
+func expenseRule(day int, start, end string) model.RecurringRule {
+	return model.RecurringRule{
+		ID:          "rec_1",
+		Type:        model.TransactionTypeExpense,
+		AmountMinor: 5000,
+		Currency:    "CAD",
+		Category:    "Rent",
+		Account:     "Checking",
+		DayOfMonth:  day,
+		StartDate:   start,
+		EndDate:     end,
+	}
+}
+
+// The current month's occurrence is generated as soon as the month has begun,
+// even when the rule's day-of-month is later in the month.
+func TestGenerateDueTransactionsGeneratesCurrentMonthBeforeDueDay(t *testing.T) {
+	repo := ruleRepo(expenseRule(28, "2026-06-01", ""))
+	svc := New(repo)
+	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+	result, err := svc.GenerateDueTransactions(now)
+	if err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+	if len(result.Generated) != 1 {
+		t.Fatalf("got %d transactions, want 1 (current month due now)", len(result.Generated))
+	}
+	if got := result.Generated[0].Date; got != "2026-06-28" {
+		t.Errorf("transaction date = %q, want 2026-06-28 (scheduled day, not generation day)", got)
+	}
+	if repo.accounts[0].BalanceMinor != 95000 {
+		t.Errorf("balance = %d, want 95000 (100000 - 5000)", repo.accounts[0].BalanceMinor)
+	}
+	if repo.rules[0].LastGeneratedMonth != "2026-06" {
+		t.Errorf("LastGeneratedMonth = %q, want 2026-06", repo.rules[0].LastGeneratedMonth)
+	}
+
+	// Running again the same month is a no-op.
+	second, err := svc.GenerateDueTransactions(now)
+	if err != nil {
+		t.Fatalf("second generation: %v", err)
+	}
+	if len(second.Generated) != 0 {
+		t.Errorf("second run generated %d, want 0 (idempotent)", len(second.Generated))
+	}
+}
+
+// Backfilling past months and generating the current month's future-day
+// occurrence happen in a single run.
+func TestGenerateDueTransactionsBackfillsAndIncludesCurrentMonth(t *testing.T) {
+	repo := ruleRepo(expenseRule(28, "2026-04-01", ""))
+	svc := New(repo)
+	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+	result, err := svc.GenerateDueTransactions(now)
+	if err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+	dates := make([]string, len(result.Generated))
+	for i, tx := range result.Generated {
+		dates[i] = tx.Date
+	}
+	want := []string{"2026-04-28", "2026-05-28", "2026-06-28"}
+	if len(dates) != len(want) {
+		t.Fatalf("got dates %v, want %v", dates, want)
+	}
+	for i := range want {
+		if dates[i] != want[i] {
+			t.Fatalf("got dates %v, want %v", dates, want)
+		}
+	}
+}
+
+// A current-month occurrence past the rule's end date is still excluded.
+func TestGenerateDueTransactionsRespectsEndDateInCurrentMonth(t *testing.T) {
+	repo := ruleRepo(expenseRule(28, "2026-06-01", "2026-06-15"))
+	svc := New(repo)
+	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+	result, err := svc.GenerateDueTransactions(now)
+	if err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+	if len(result.Generated) != 0 {
+		t.Errorf("got %d transactions, want 0 (28th is past the 15th end date)", len(result.Generated))
+	}
+}
+
+// Future months are never generated, even when the current month is.
+func TestGenerateDueTransactionsDoesNotGenerateFutureMonths(t *testing.T) {
+	repo := ruleRepo(expenseRule(28, "2026-06-01", ""))
+	svc := New(repo)
+	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+
+	result, err := svc.GenerateDueTransactions(now)
+	if err != nil {
+		t.Fatalf("generation: %v", err)
+	}
+	for _, tx := range result.Generated {
+		if tx.Date > "2026-06-30" {
+			t.Errorf("generated a future-month transaction dated %q", tx.Date)
+		}
+	}
+	if len(result.Generated) != 1 {
+		t.Errorf("got %d transactions, want exactly 1 (current month only)", len(result.Generated))
+	}
+}


### PR DESCRIPTION
## Summary

A recurring rule used to wait until its day-of-month arrived before generating the current month's transaction — a rule due on the 28th produced nothing until the 28th. Now the current month's occurrence is generated **as soon as the month begins**, dated to the scheduled day.

Example: on 2026-06-01, a rule due on the 28th generates its `2026-06-28` transaction immediately, instead of waiting 27 days.

This is an intentional revision of the original "skip months whose date is still in the future" rule from the recurring feature (#9, still unreleased).

## What changed

- Removed the `if txDate.After(today) { break }` gate in `dueTransactionsForRule`. The loop already caps iteration at the current month (`for !cursor.After(currentMonth)`), and the start-date and end-date bounds are untouched — so this generates **no** future months and **no** out-of-range occurrences. It only unblocks the current month's later-in-the-month occurrence.
- Reused the already-parsed `startTime` instead of re-parsing `rule.StartDate` (with an ignored error) on every loop iteration.
- Added a forward-looking note at the generation site: `DayOfMonth` is capped at 1..28 today, but if days 29..31 are ever allowed (#10), the date must be clamped to month-end here, since the current month is now materialized eagerly.

## Behavior decisions

- **Whole current month** — the occurrence generates once the month has begun, regardless of its day (your request). A rule starting later this month still generates its in-month occurrence, since eligibility is judged by the occurrence date within `[start, end]`.
- **Dated to the scheduled day** — the transaction is dated `2026-06-28`, not the generation date, so reports and budgets attribute it to when it's actually due. This matches how backfilled past months were already dated.

## Note (by design, surfaced for awareness)

Recurring generation has always applied the balance effect at generation time. With this change, that now happens up to ~27 days earlier, so for most of the month the account balance and the month's budget "spent" reflect an expense whose scheduled date hasn't arrived yet. This is consistent with the existing immediate-balance model (not newly introduced), but it does make the ledger more forecast-style for the current month. Related to #14 (a "pending vs generated" nudge would complement this); this PR does not address #14.

## Testing

- New tests: current-month-before-due-day generates and is idempotent on re-run; backfill of past months + current month in a single run (`[04-28, 05-28, 06-28]`); end-date still excludes a current-month occurrence past the end; future months are never generated.
- I verified the new tests fail against the pre-change code (current-month returned 0, backfill skipped June) and pass against the change — genuine regression guards.
- `go test ./...`, `go build`, `go vet`, `gofmt` all clean.