### PR TITLE
Add interactive CSV transaction import

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Local-first CLI tool for tracking personal finances.
 ## Current Features
 
 - Interactive transaction entry: `coinw add`
+- Interactive CSV import: `coinw import <file.csv>`
 - Interactive transaction editing: `coinw edit`
 - Interactive transaction deletion: `coinw delete`
 - Interactive account management: `coinw account`

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/amiraminb/coinwarrior/internal/importer"
+	"github.com/amiraminb/coinwarrior/internal/tui"
+	"github.com/spf13/cobra"
+)
+
+var importCmd = &cobra.Command{
+	Use:   "import <file>",
+	Short: "Import transactions from a CSV file, categorizing each row interactively",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		rows, err := importer.ParseFile(args[0])
+		if err != nil {
+			return err
+		}
+		return tui.RunImport(rows)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(importCmd)
+}

--- a/internal/importer/csv.go
+++ b/internal/importer/csv.go
@@ -1,0 +1,145 @@
+package importer
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/amiraminb/coinwarrior/internal/model"
+)
+
+// csvDateLayout is the date format used by the bank export (MM/DD/YYYY).
+const csvDateLayout = "01/02/2006"
+
+// expectedColumns is the minimum column count of a supported export row:
+// transaction date, transaction type, debit amount, credit amount, extended text.
+const expectedColumns = 5
+
+// ParsedRow is one transaction read from the CSV, normalized into the fields the
+// import flow needs. AmountInput stays a string so the canonical money.Parse rules
+// apply later at save time rather than being duplicated here. A row that fails to
+// normalize is still returned with ParseErr set so the caller can let the user fix
+// it instead of silently dropping data.
+type ParsedRow struct {
+	// RowNo is the 1-based position of this row among data rows (header excluded),
+	// used for user-facing "row N of M" messaging.
+	RowNo       int
+	Date        string
+	Type        string
+	AmountInput string
+	Note        string
+	ParseErr    error
+}
+
+// ParseFile reads and parses a bank-export CSV at path.
+func ParseFile(path string) ([]ParsedRow, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return ParseReader(file)
+}
+
+// ParseReader parses a bank-export CSV from r. The first record is treated as a
+// header and discarded. The returned error covers only failures that make the
+// whole file unusable; per-row problems are reported via ParsedRow.ParseErr.
+func ParseReader(r io.Reader) ([]ParsedRow, error) {
+	reader := csv.NewReader(r)
+	reader.FieldsPerRecord = -1
+	reader.TrimLeadingSpace = true
+
+	if _, err := reader.Read(); err == io.EOF {
+		return nil, fmt.Errorf("csv file is empty")
+	} else if err != nil {
+		return nil, fmt.Errorf("reading header: %w", err)
+	}
+
+	var rows []ParsedRow
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("reading row %d: %w", len(rows)+1, err)
+		}
+		if isBlankRecord(record) {
+			continue
+		}
+		rows = append(rows, parseRecord(record, len(rows)+1))
+	}
+
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("csv file has no data rows")
+	}
+
+	return rows, nil
+}
+
+func parseRecord(record []string, rowNo int) ParsedRow {
+	row := ParsedRow{RowNo: rowNo}
+
+	if len(record) < expectedColumns {
+		row.ParseErr = fmt.Errorf("expected %d columns, got %d", expectedColumns, len(record))
+		return row
+	}
+
+	rawDate := strings.TrimSpace(record[0])
+	bankType := strings.TrimSpace(record[1])
+	debit := strings.TrimSpace(record[2])
+	credit := strings.TrimSpace(record[3])
+	extended := strings.TrimSpace(record[4])
+
+	row.Note = composeNote(bankType, extended)
+
+	switch {
+	case debit != "" && credit != "":
+		row.ParseErr = fmt.Errorf("row has both debit (%s) and credit (%s) amounts", debit, credit)
+	case debit != "":
+		row.Type = model.TransactionTypeExpense
+		row.AmountInput = debit
+	case credit != "":
+		row.Type = model.TransactionTypeIncome
+		row.AmountInput = credit
+	default:
+		row.ParseErr = fmt.Errorf("row has no debit or credit amount")
+	}
+
+	if parsed, err := time.Parse(csvDateLayout, rawDate); err != nil {
+		row.Date = rawDate
+		if row.ParseErr == nil {
+			row.ParseErr = fmt.Errorf("invalid date %q (expected MM/DD/YYYY)", rawDate)
+		}
+	} else {
+		row.Date = parsed.Format("2006-01-02")
+	}
+
+	return row
+}
+
+// composeNote folds the bank's transaction-type string and the extended text into
+// a single note, keeping whichever side is present.
+func composeNote(bankType, extended string) string {
+	switch {
+	case bankType != "" && extended != "":
+		return bankType + ": " + extended
+	case bankType != "":
+		return bankType
+	default:
+		return extended
+	}
+}
+
+func isBlankRecord(record []string) bool {
+	for _, field := range record {
+		if strings.TrimSpace(field) != "" {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/importer/csv_test.go
+++ b/internal/importer/csv_test.go
@@ -1,0 +1,133 @@
+package importer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/amiraminb/coinwarrior/internal/model"
+)
+
+const header = "Transaction Date,Transaction Type,Debit Amount,Credit Amount,Extended Text\n"
+
+func TestParseReader(t *testing.T) {
+	tests := []struct {
+		name       string
+		row        string
+		wantDate   string
+		wantType   string
+		wantAmount string
+		wantNote   string
+		wantErr    bool
+	}{
+		{
+			name:       "debit becomes expense",
+			row:        "06/23/2026,POS PURCHASE,12.34,,COFFEE SHOP",
+			wantDate:   "2026-06-23",
+			wantType:   model.TransactionTypeExpense,
+			wantAmount: "12.34",
+			wantNote:   "POS PURCHASE: COFFEE SHOP",
+		},
+		{
+			name:       "credit becomes income",
+			row:        "01/05/2026,DIRECT DEPOSIT,,2000.00,PAYROLL",
+			wantDate:   "2026-01-05",
+			wantType:   model.TransactionTypeIncome,
+			wantAmount: "2000.00",
+			wantNote:   "DIRECT DEPOSIT: PAYROLL",
+		},
+		{
+			name:       "note with only extended text",
+			row:        "12/31/2025,,5.00,,SOMETHING",
+			wantDate:   "2025-12-31",
+			wantType:   model.TransactionTypeExpense,
+			wantAmount: "5.00",
+			wantNote:   "SOMETHING",
+		},
+		{
+			name:     "invalid date flagged",
+			row:      "2026-06-23,POS,12.34,,COFFEE",
+			wantErr:  true,
+			wantType: model.TransactionTypeExpense,
+		},
+		{
+			name:    "both debit and credit flagged",
+			row:     "06/23/2026,XFER,10.00,20.00,AMBIGUOUS",
+			wantErr: true,
+		},
+		{
+			name:    "neither debit nor credit flagged",
+			row:     "06/23/2026,FEE,,,NO AMOUNT",
+			wantErr: true,
+		},
+		{
+			name:    "too few columns flagged",
+			row:     "06/23/2026,POS,12.34",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rows, err := ParseReader(strings.NewReader(header + tc.row + "\n"))
+			if err != nil {
+				t.Fatalf("ParseReader returned file error: %v", err)
+			}
+			if len(rows) != 1 {
+				t.Fatalf("got %d rows, want 1", len(rows))
+			}
+			row := rows[0]
+
+			if tc.wantErr {
+				if row.ParseErr == nil {
+					t.Fatalf("expected ParseErr, got none (row=%+v)", row)
+				}
+				return
+			}
+			if row.ParseErr != nil {
+				t.Fatalf("unexpected ParseErr: %v", row.ParseErr)
+			}
+			if row.Date != tc.wantDate {
+				t.Errorf("Date = %q, want %q", row.Date, tc.wantDate)
+			}
+			if row.Type != tc.wantType {
+				t.Errorf("Type = %q, want %q", row.Type, tc.wantType)
+			}
+			if row.AmountInput != tc.wantAmount {
+				t.Errorf("AmountInput = %q, want %q", row.AmountInput, tc.wantAmount)
+			}
+			if row.Note != tc.wantNote {
+				t.Errorf("Note = %q, want %q", row.Note, tc.wantNote)
+			}
+		})
+	}
+}
+
+func TestParseReaderSkipsHeaderAndBlankLines(t *testing.T) {
+	input := header +
+		"06/23/2026,POS,12.34,,A\n" +
+		"\n" +
+		"06/24/2026,POS,,5.00,B\n"
+
+	rows, err := ParseReader(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("ParseReader error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2 (header and blank line should be skipped)", len(rows))
+	}
+	if rows[0].RowNo != 1 || rows[1].RowNo != 2 {
+		t.Errorf("row numbers = %d,%d, want 1,2", rows[0].RowNo, rows[1].RowNo)
+	}
+}
+
+func TestParseReaderEmptyFile(t *testing.T) {
+	if _, err := ParseReader(strings.NewReader("")); err == nil {
+		t.Fatal("expected error for empty file")
+	}
+}
+
+func TestParseReaderHeaderOnly(t *testing.T) {
+	if _, err := ParseReader(strings.NewReader(header)); err == nil {
+		t.Fatal("expected error for file with no data rows")
+	}
+}

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -9,6 +9,10 @@ import (
 	"github.com/amiraminb/coinwarrior/internal/money"
 )
 
+func (s *Service) LoadAccounts() ([]model.Account, error) {
+	return s.repo.LoadAccounts()
+}
+
 func (s *Service) LoadAccountNames() ([]string, error) {
 	accounts, err := s.repo.LoadAccounts()
 	if err != nil {

--- a/internal/tui/import.go
+++ b/internal/tui/import.go
@@ -1,0 +1,357 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/amiraminb/coinwarrior/internal/importer"
+	"github.com/amiraminb/coinwarrior/internal/model"
+	"github.com/amiraminb/coinwarrior/internal/money"
+)
+
+const newAccountSentinel = "\x00new-account"
+
+type rowAction int
+
+const (
+	rowSave rowAction = iota
+	rowSkip
+	rowQuit
+)
+
+// RunImport walks the parsed CSV rows one at a time, letting the user assign a
+// category and save, skip, edit, or quit. Currency and account are asked once up
+// front and applied to every saved row. Rows accepted before a quit stay saved.
+func RunImport(rows []importer.ParsedRow) error {
+	account, currency, ok, err := promptAccount()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		fmt.Println("import cancelled")
+		return nil
+	}
+
+	categories, err := Svc.LoadCategories()
+	if err != nil {
+		return err
+	}
+
+	saved, skipped := 0, 0
+	for i, row := range rows {
+		action, updated, category, err := runRow(row, i, len(rows), currency, account, categories)
+		if err != nil {
+			return err
+		}
+		switch action {
+		case rowSave:
+			if err := Svc.AddCategory(category); err != nil {
+				return err
+			}
+			tx, err := Svc.AddTransaction(updated.Type, updated.AmountInput, currency, updated.Date, category, account, "", updated.Note)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("saved transaction: %s\n", tx.ID)
+			saved++
+			if categories, err = Svc.LoadCategories(); err != nil {
+				return err
+			}
+		case rowSkip:
+			skipped++
+		case rowQuit:
+			remaining := len(rows) - i
+			fmt.Printf("import stopped: %d saved, %d skipped, %d remaining\n", saved, skipped, remaining)
+			return nil
+		}
+	}
+
+	fmt.Printf("import complete: %d saved, %d skipped\n", saved, skipped)
+	return nil
+}
+
+// runRow drives the interactive menu for a single row until the user saves,
+// skips, or quits. A save attempt that fails validation (no category yet, an
+// unresolved parse error, or a service rejection) keeps the user on the menu
+// with the reason shown instead of aborting the whole import.
+func runRow(row importer.ParsedRow, index, total int, currency, account string, categories []string) (rowAction, importer.ParsedRow, string, error) {
+	category := ""
+	warning := ""
+	if row.ParseErr != nil {
+		warning = row.ParseErr.Error()
+	}
+
+	for {
+		title := HeaderStyle.Render(fmt.Sprintf("Row %d of %d", index+1, total))
+		prompt := rowSummary(row, category, currency, account, warning)
+
+		categoryLabel := "Set category"
+		if category != "" {
+			categoryLabel = "Change category (" + category + ")"
+		}
+		items := []selectionItem[string]{
+			{label: categoryLabel, value: "category"},
+			{label: "Save", value: "save"},
+			{label: "Edit amount / date / note", value: "edit"},
+			{label: "Skip", value: "skip"},
+			{label: "Quit import", value: "quit"},
+		}
+
+		choice, chose, err := runSelection(title, prompt, items)
+		if err != nil {
+			return rowSkip, row, "", err
+		}
+		if !chose {
+			// esc/q on the menu skips this row rather than quitting the run;
+			// "Quit import" is an explicit menu item.
+			return rowSkip, row, "", nil
+		}
+
+		switch choice {
+		case "category":
+			picked, ok, err := runCategoryPicker(categories)
+			if err != nil {
+				return rowSkip, row, "", err
+			}
+			if ok {
+				category = picked
+			}
+		case "save":
+			switch {
+			case row.ParseErr != nil:
+				warning = "fix the row before saving: " + row.ParseErr.Error()
+			case category == "":
+				warning = "choose a category before saving"
+			default:
+				return rowSave, row, category, nil
+			}
+		case "edit":
+			updated, err := runRowEdit(row)
+			if err != nil {
+				return rowSkip, row, "", err
+			}
+			row = updated
+			if row.ParseErr != nil {
+				warning = row.ParseErr.Error()
+			} else {
+				warning = ""
+			}
+		case "skip":
+			return rowSkip, row, "", nil
+		case "quit":
+			return rowQuit, row, "", nil
+		}
+	}
+}
+
+func rowSummary(row importer.ParsedRow, category, currency, account, warning string) string {
+	s := renderField("Date: ", row.Date) + "\n"
+	s += renderField("Type: ", row.Type) + "\n"
+	s += renderField("Amount: ", row.AmountInput+" "+currency) + "\n"
+	s += renderField("Account: ", account) + "\n"
+	if category != "" {
+		s += renderField("Category: ", category) + "\n"
+	}
+	if row.Note != "" {
+		s += renderField("Note: ", row.Note) + "\n"
+	}
+	if warning != "" {
+		s += "\n" + warnStyle.Render(warning) + "\n"
+	}
+	return s
+}
+
+// runRowEdit lets the user revise amount, date, and note for one row, clearing
+// the parse error if the edited values are now valid.
+func runRowEdit(row importer.ParsedRow) (importer.ParsedRow, error) {
+	for {
+		items := []selectionItem[string]{
+			{label: "Amount (" + row.AmountInput + ")", value: "amount"},
+			{label: "Date (" + row.Date + ")", value: "date"},
+			{label: "Note (" + row.Note + ")", value: "note"},
+			{label: "Done", value: "done"},
+		}
+		choice, chose, err := runSelection(HeaderStyle.Render("Edit row"), "", items)
+		if err != nil {
+			return row, err
+		}
+		if !chose || choice == "done" {
+			return revalidateRow(row), nil
+		}
+
+		switch choice {
+		case "amount":
+			value, ok, err := runTextPrompt("Edit amount", "Amount: ", row.AmountInput, validateAmount)
+			if err != nil {
+				return row, err
+			}
+			if ok {
+				row.AmountInput = value
+			}
+		case "date":
+			value, ok, err := runTextPrompt("Edit date", "Date (YYYY-MM-DD): ", row.Date, validateDate)
+			if err != nil {
+				return row, err
+			}
+			if ok {
+				row.Date = value
+			}
+		case "note":
+			value, ok, err := runTextPrompt("Edit note", "Note: ", row.Note, nil)
+			if err != nil {
+				return row, err
+			}
+			if ok {
+				row.Note = value
+			}
+		}
+	}
+}
+
+// revalidateRow recomputes ParseErr after edits so a row that was flagged on
+// import can clear its error once amount and date are valid.
+func revalidateRow(row importer.ParsedRow) importer.ParsedRow {
+	row.ParseErr = nil
+	if err := validateAmount(row.AmountInput); err != nil {
+		row.ParseErr = err
+		return row
+	}
+	if err := validateDate(row.Date); err != nil {
+		row.ParseErr = err
+	}
+	return row
+}
+
+func validateAmount(s string) error {
+	amountMinor, err := money.Parse(s)
+	if err != nil {
+		return err
+	}
+	if amountMinor <= 0 {
+		return fmt.Errorf("amount must be greater than zero")
+	}
+	return nil
+}
+
+func validateDate(s string) error {
+	if _, err := time.Parse("2006-01-02", strings.TrimSpace(s)); err != nil {
+		return fmt.Errorf("invalid date format: %s", s)
+	}
+	return nil
+}
+
+// promptAccount asks the user to pick the account that imported rows post to,
+// returning that account's name and currency. The import currency is derived from
+// the chosen account rather than asked separately: an existing account has a fixed
+// currency, and posting a differing currency would make every save fail the
+// account-currency check in the service layer. Currency is only entered when the
+// user creates a new account.
+func promptAccount() (string, string, bool, error) {
+	accounts, err := Svc.LoadAccounts()
+	if err != nil {
+		return "", "", false, err
+	}
+
+	items := make([]selectionItem[string], 0, len(accounts)+1)
+	for _, account := range accounts {
+		items = append(items, selectionItem[string]{
+			label: account.Name + " (" + account.Currency + ")",
+			value: account.Name,
+		})
+	}
+	items = append(items, selectionItem[string]{label: "[New account]", value: newAccountSentinel})
+
+	choice, chose, err := runSelection(HeaderStyle.Render("Import setup"), "Account for imported rows:", items)
+	if err != nil || !chose {
+		return "", "", chose, err
+	}
+	if choice != newAccountSentinel {
+		for _, account := range accounts {
+			if account.Name == choice {
+				return account.Name, account.Currency, true, nil
+			}
+		}
+	}
+
+	return promptNewAccount(accounts)
+}
+
+func promptNewAccount(existing []model.Account) (string, string, bool, error) {
+	nameValidate := func(s string) error {
+		if strings.TrimSpace(s) == "" {
+			return fmt.Errorf("account name is required")
+		}
+		return nil
+	}
+	name, ok, err := runTextPrompt(HeaderStyle.Render("New account"), "Account name: ", "", nameValidate)
+	if err != nil || !ok {
+		return "", "", ok, err
+	}
+
+	for _, account := range existing {
+		if strings.EqualFold(account.Name, name) {
+			return account.Name, account.Currency, true, nil
+		}
+	}
+
+	currencyValidate := func(s string) error {
+		if money.NormalizeCurrency(s) == "" {
+			return fmt.Errorf("currency is required")
+		}
+		return nil
+	}
+	currencyInput, ok, err := runTextPrompt(HeaderStyle.Render("New account"), "Currency: ", "CAD", currencyValidate)
+	if err != nil || !ok {
+		return "", "", ok, err
+	}
+	currency := money.NormalizeCurrency(currencyInput)
+
+	if _, err := Svc.AddAccount(name, currency, "0"); err != nil {
+		return "", "", false, err
+	}
+	return name, currency, true, nil
+}
+
+// runCategoryPicker reproduces the add flow's select-or-create category UX from
+// the shared prompt primitives: pick an existing category or enter a new one,
+// confirming creation of an unknown name.
+func runCategoryPicker(categories []string) (string, bool, error) {
+	items := make([]selectionItem[string], 0, len(categories)+1)
+	for _, c := range categories {
+		items = append(items, selectionItem[string]{label: c, value: c})
+	}
+	const newCategorySentinel = "\x00new-category"
+	items = append(items, selectionItem[string]{label: "[New category]", value: newCategorySentinel})
+
+	choice, chose, err := runSelection(HeaderStyle.Render("Category"), "Select category:", items)
+	if err != nil || !chose {
+		return "", chose, err
+	}
+	if choice != newCategorySentinel {
+		return choice, true, nil
+	}
+
+	for {
+		validate := func(s string) error {
+			if strings.TrimSpace(s) == "" {
+				return fmt.Errorf("category is required")
+			}
+			return nil
+		}
+		draft, ok, err := runTextPrompt(HeaderStyle.Render("New category"), "Category: ", "", validate)
+		if err != nil || !ok {
+			return "", ok, err
+		}
+		if containsFold(categories, draft) {
+			return draft, true, nil
+		}
+		create, err := RunConfirmPrompt(warnStyle.Render("Category '" + draft + "' is new. Create it?"))
+		if err != nil {
+			return "", false, err
+		}
+		if create {
+			return draft, true, nil
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds `coinw import <file.csv>` — read a bank-export CSV and walk through each row interactively to assign a category and **Save / Skip / Edit / Quit**.

- **CSV shape:** `transaction date, transaction type, debit amount, credit amount, extended text` (header row skipped)
- **Date:** `MM/DD/YYYY` normalized to ISO `YYYY-MM-DD`
- **Type:** debit → expense, credit → income; bank type string folded into the note
- **Account/currency:** chosen once up front. Currency is derived from the selected account (only entered when creating a new account) so imported rows never fail the service-layer account-currency check
- **Bad rows** (unparseable date, ambiguous debit/credit) are flagged, not dropped — the user fixes them via the Edit step before saving

## Implementation

- `internal/importer` — standalone, unit-tested CSV parser (`ParseFile`/`ParseReader`), amounts kept as strings so `money.Parse` rules stay single-sourced
- `internal/tui/import.go` — per-row interactive flow composed from existing prompt primitives (`runSelection`, `runTextPrompt`, `RunConfirmPrompt`); no changes to the existing `add` flow
- `cmd/import.go` — cobra command wiring

## Testing

- `go build ./...`, `go vet ./...`, full suite: **98 tests pass** (11 new parser tests)
- Verified command help, arg validation, and file-error paths; parser verified end-to-end on a sample including a bad-date row
- A local multi-agent code review surfaced one real bug (existing-account currency mismatch aborting the import), fixed here by deriving currency from the chosen account

The interactive TUI walkthrough itself was not auto-run (needs a TTY and would write to the real local ledger).