### PR TITLE
Fix CSV import column mapping

### DIFF
--- a/internal/importer/csv.go
+++ b/internal/importer/csv.go
@@ -14,9 +14,19 @@ import (
 // csvDateLayout is the date format used by the bank export (MM/DD/YYYY).
 const csvDateLayout = "01/02/2006"
 
-// expectedColumns is the minimum column count of a supported export row:
-// transaction date, transaction type, debit amount, credit amount, extended text.
-const expectedColumns = 5
+// Column header names the parser looks up (case-insensitively). Columns are matched
+// by header name rather than fixed position so the export's column order and any
+// extra columns do not matter.
+const (
+	colDate     = "transaction date"
+	colType     = "transaction type"
+	colDebit    = "debit amount"
+	colCredit   = "credit amount"
+	colExtended = "extended text"
+)
+
+// requiredColumns must be present in the header for the file to be usable.
+var requiredColumns = []string{colDate, colDebit, colCredit}
 
 // ParsedRow is one transaction read from the CSV, normalized into the fields the
 // import flow needs. AmountInput stays a string so the canonical money.Parse rules
@@ -53,10 +63,16 @@ func ParseReader(r io.Reader) ([]ParsedRow, error) {
 	reader.FieldsPerRecord = -1
 	reader.TrimLeadingSpace = true
 
-	if _, err := reader.Read(); err == io.EOF {
+	header, err := reader.Read()
+	if err == io.EOF {
 		return nil, fmt.Errorf("csv file is empty")
 	} else if err != nil {
 		return nil, fmt.Errorf("reading header: %w", err)
+	}
+
+	columns, err := indexColumns(header)
+	if err != nil {
+		return nil, err
 	}
 
 	var rows []ParsedRow
@@ -71,7 +87,7 @@ func ParseReader(r io.Reader) ([]ParsedRow, error) {
 		if isBlankRecord(record) {
 			continue
 		}
-		rows = append(rows, parseRecord(record, len(rows)+1))
+		rows = append(rows, parseRecord(record, len(rows)+1, columns))
 	}
 
 	if len(rows) == 0 {
@@ -81,19 +97,39 @@ func ParseReader(r io.Reader) ([]ParsedRow, error) {
 	return rows, nil
 }
 
-func parseRecord(record []string, rowNo int) ParsedRow {
-	row := ParsedRow{RowNo: rowNo}
-
-	if len(record) < expectedColumns {
-		row.ParseErr = fmt.Errorf("expected %d columns, got %d", expectedColumns, len(record))
-		return row
+// indexColumns maps each required and optional column name to its position in the
+// header, matching case-insensitively. It errors only when a required column is
+// missing, since the whole file is then unusable.
+func indexColumns(header []string) (map[string]int, error) {
+	columns := make(map[string]int, len(header))
+	for i, name := range header {
+		// Strip a UTF-8 BOM the export may prepend to the first header cell,
+		// otherwise its name won't match and a required column looks missing.
+		name = strings.TrimPrefix(name, "\uFEFF")
+		columns[strings.ToLower(strings.TrimSpace(name))] = i
 	}
 
-	rawDate := strings.TrimSpace(record[0])
-	bankType := strings.TrimSpace(record[1])
-	debit := strings.TrimSpace(record[2])
-	credit := strings.TrimSpace(record[3])
-	extended := strings.TrimSpace(record[4])
+	var missing []string
+	for _, name := range requiredColumns {
+		if _, ok := columns[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("csv is missing required column(s): %s", strings.Join(missing, ", "))
+	}
+
+	return columns, nil
+}
+
+func parseRecord(record []string, rowNo int, columns map[string]int) ParsedRow {
+	row := ParsedRow{RowNo: rowNo}
+
+	rawDate := field(record, columns, colDate)
+	bankType := field(record, columns, colType)
+	debit := field(record, columns, colDebit)
+	credit := field(record, columns, colCredit)
+	extended := field(record, columns, colExtended)
 
 	row.Note = composeNote(bankType, extended)
 
@@ -133,6 +169,16 @@ func composeNote(bankType, extended string) string {
 	default:
 		return extended
 	}
+}
+
+// field returns the trimmed value of the named column for a record, or "" when the
+// column is absent from the header or the record is too short to include it.
+func field(record []string, columns map[string]int, name string) string {
+	idx, ok := columns[name]
+	if !ok || idx >= len(record) {
+		return ""
+	}
+	return strings.TrimSpace(record[idx])
 }
 
 func isBlankRecord(record []string) bool {

--- a/internal/importer/csv_test.go
+++ b/internal/importer/csv_test.go
@@ -7,12 +7,20 @@ import (
 	"github.com/amiraminb/coinwarrior/internal/model"
 )
 
-const header = "Transaction Date,Transaction Type,Debit Amount,Credit Amount,Extended Text\n"
+// header mirrors the real bank export: 10 columns, with the relevant ones at
+// non-leading positions, so the tests exercise name-based column mapping.
+const header = "Transaction Date,Account Rtn,Account Number,Transaction Type,Customer Reference Number,Debit Amount,Credit Amount,Principal Balance Amount,Extended Text,Bank Reference Number\n"
+
+// row builds a 10-column data line matching header from the fields the parser cares about.
+func row(date, txType, debit, credit, extended string) string {
+	cols := []string{date, "021000021", "12345678", txType, "REF001", debit, credit, "1000.00", extended, "BNK999"}
+	return strings.Join(cols, ",") + "\n"
+}
 
 func TestParseReader(t *testing.T) {
 	tests := []struct {
 		name       string
-		row        string
+		line       string
 		wantDate   string
 		wantType   string
 		wantAmount string
@@ -21,7 +29,7 @@ func TestParseReader(t *testing.T) {
 	}{
 		{
 			name:       "debit becomes expense",
-			row:        "06/23/2026,POS PURCHASE,12.34,,COFFEE SHOP",
+			line:       row("06/23/2026", "POS PURCHASE", "12.34", "", "COFFEE SHOP"),
 			wantDate:   "2026-06-23",
 			wantType:   model.TransactionTypeExpense,
 			wantAmount: "12.34",
@@ -29,7 +37,7 @@ func TestParseReader(t *testing.T) {
 		},
 		{
 			name:       "credit becomes income",
-			row:        "01/05/2026,DIRECT DEPOSIT,,2000.00,PAYROLL",
+			line:       row("01/05/2026", "DIRECT DEPOSIT", "", "2000.00", "PAYROLL"),
 			wantDate:   "2026-01-05",
 			wantType:   model.TransactionTypeIncome,
 			wantAmount: "2000.00",
@@ -37,7 +45,7 @@ func TestParseReader(t *testing.T) {
 		},
 		{
 			name:       "note with only extended text",
-			row:        "12/31/2025,,5.00,,SOMETHING",
+			line:       row("12/31/2025", "", "5.00", "", "SOMETHING"),
 			wantDate:   "2025-12-31",
 			wantType:   model.TransactionTypeExpense,
 			wantAmount: "5.00",
@@ -45,68 +53,109 @@ func TestParseReader(t *testing.T) {
 		},
 		{
 			name:     "invalid date flagged",
-			row:      "2026-06-23,POS,12.34,,COFFEE",
+			line:     row("2026-06-23", "POS", "12.34", "", "COFFEE"),
 			wantErr:  true,
 			wantType: model.TransactionTypeExpense,
 		},
 		{
 			name:    "both debit and credit flagged",
-			row:     "06/23/2026,XFER,10.00,20.00,AMBIGUOUS",
+			line:    row("06/23/2026", "XFER", "10.00", "20.00", "AMBIGUOUS"),
 			wantErr: true,
 		},
 		{
 			name:    "neither debit nor credit flagged",
-			row:     "06/23/2026,FEE,,,NO AMOUNT",
-			wantErr: true,
-		},
-		{
-			name:    "too few columns flagged",
-			row:     "06/23/2026,POS,12.34",
+			line:    row("06/23/2026", "FEE", "", "", "NO AMOUNT"),
 			wantErr: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rows, err := ParseReader(strings.NewReader(header + tc.row + "\n"))
+			rows, err := ParseReader(strings.NewReader(header + tc.line))
 			if err != nil {
 				t.Fatalf("ParseReader returned file error: %v", err)
 			}
 			if len(rows) != 1 {
 				t.Fatalf("got %d rows, want 1", len(rows))
 			}
-			row := rows[0]
+			r := rows[0]
 
 			if tc.wantErr {
-				if row.ParseErr == nil {
-					t.Fatalf("expected ParseErr, got none (row=%+v)", row)
+				if r.ParseErr == nil {
+					t.Fatalf("expected ParseErr, got none (row=%+v)", r)
 				}
 				return
 			}
-			if row.ParseErr != nil {
-				t.Fatalf("unexpected ParseErr: %v", row.ParseErr)
+			if r.ParseErr != nil {
+				t.Fatalf("unexpected ParseErr: %v", r.ParseErr)
 			}
-			if row.Date != tc.wantDate {
-				t.Errorf("Date = %q, want %q", row.Date, tc.wantDate)
+			if r.Date != tc.wantDate {
+				t.Errorf("Date = %q, want %q", r.Date, tc.wantDate)
 			}
-			if row.Type != tc.wantType {
-				t.Errorf("Type = %q, want %q", row.Type, tc.wantType)
+			if r.Type != tc.wantType {
+				t.Errorf("Type = %q, want %q", r.Type, tc.wantType)
 			}
-			if row.AmountInput != tc.wantAmount {
-				t.Errorf("AmountInput = %q, want %q", row.AmountInput, tc.wantAmount)
+			if r.AmountInput != tc.wantAmount {
+				t.Errorf("AmountInput = %q, want %q", r.AmountInput, tc.wantAmount)
 			}
-			if row.Note != tc.wantNote {
-				t.Errorf("Note = %q, want %q", row.Note, tc.wantNote)
+			if r.Note != tc.wantNote {
+				t.Errorf("Note = %q, want %q", r.Note, tc.wantNote)
 			}
 		})
 	}
 }
 
+func TestParseReaderMapsByHeaderNameIgnoringOrder(t *testing.T) {
+	// Columns deliberately reordered and an extra column added; name-based mapping
+	// should still pick out the right fields.
+	input := "Extended Text,Credit Amount,Transaction Date,Debit Amount,Transaction Type,Junk\n" +
+		"GROCERIES,,06/23/2026,45.67,POS,ignored\n"
+
+	rows, err := ParseReader(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("ParseReader error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	r := rows[0]
+	if r.ParseErr != nil {
+		t.Fatalf("unexpected ParseErr: %v", r.ParseErr)
+	}
+	if r.Date != "2026-06-23" || r.Type != model.TransactionTypeExpense || r.AmountInput != "45.67" || r.Note != "POS: GROCERIES" {
+		t.Errorf("mismapped row: %+v", r)
+	}
+}
+
+func TestParseReaderStripsUTF8BOM(t *testing.T) {
+	// A UTF-8 BOM prepended to the file lands on the first header cell; it must be
+	// stripped so the column still matches and the file is not rejected.
+	input := "\uFEFF" + header + row("06/23/2026", "POS", "12.34", "", "COFFEE")
+	rows, err := ParseReader(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("ParseReader error with BOM: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ParseErr != nil {
+		t.Fatalf("BOM not handled: rows=%+v", rows)
+	}
+	if rows[0].Date != "2026-06-23" || rows[0].AmountInput != "12.34" {
+		t.Errorf("BOM row mismapped: %+v", rows[0])
+	}
+}
+
+func TestParseReaderMissingRequiredColumn(t *testing.T) {
+	// No Debit Amount / Credit Amount columns at all.
+	input := "Transaction Date,Transaction Type,Extended Text\n06/23/2026,POS,COFFEE\n"
+	if _, err := ParseReader(strings.NewReader(input)); err == nil {
+		t.Fatal("expected error for missing required columns")
+	}
+}
+
 func TestParseReaderSkipsHeaderAndBlankLines(t *testing.T) {
 	input := header +
-		"06/23/2026,POS,12.34,,A\n" +
+		row("06/23/2026", "POS", "12.34", "", "A") +
 		"\n" +
-		"06/24/2026,POS,,5.00,B\n"
+		row("06/24/2026", "DEP", "", "5.00", "B")
 
 	rows, err := ParseReader(strings.NewReader(input))
 	if err != nil {


### PR DESCRIPTION
## Problem

After #22, importing a real bank-export CSV showed the Date correctly but left **Type, Amount, and Note empty**. The parser read fixed column positions (`date, type, debit, credit, extended text` at indices 0–4), but real exports place those fields at different offsets and include extra columns. For a 10-column export (`Transaction Date, Account Rtn, Account Number, Transaction Type, Customer Reference Number, Debit Amount, Credit Amount, Principal Balance Amount, Extended Text, Bank Reference Number`), indices 1–4 held routing/account/reference data, not the intended fields.

## Fix

Map columns by **header name** (case-insensitive) instead of fixed position:

- Robust to column order and extra columns — only the named columns are read
- Required columns (`transaction date`, `debit amount`, `credit amount`) are validated against the header up front; a missing one fails the file with a clear message
- `transaction type` and `extended text` are optional (they only affect the note)
- A UTF-8 BOM on the first header cell is stripped, so a BOM-prefixed export is not wrongly rejected as "missing transaction date"

## Testing

- `go build`, `go vet`, full suite: **100 tests pass**
- New parser tests: name-based mapping with reordered + extra columns, missing-required-column error, and UTF-8 BOM handling
- Verified end-to-end against the exact 10-column layout: date/type/amount/note all populate correctly