### PR TITLE
Use only Extended Text for imported transaction notes

### DIFF
--- a/internal/importer/csv.go
+++ b/internal/importer/csv.go
@@ -19,7 +19,6 @@ const csvDateLayout = "01/02/2006"
 // extra columns do not matter.
 const (
 	colDate     = "transaction date"
-	colType     = "transaction type"
 	colDebit    = "debit amount"
 	colCredit   = "credit amount"
 	colExtended = "extended text"
@@ -126,12 +125,10 @@ func parseRecord(record []string, rowNo int, columns map[string]int) ParsedRow {
 	row := ParsedRow{RowNo: rowNo}
 
 	rawDate := field(record, columns, colDate)
-	bankType := field(record, columns, colType)
 	debit := field(record, columns, colDebit)
 	credit := field(record, columns, colCredit)
-	extended := field(record, columns, colExtended)
 
-	row.Note = composeNote(bankType, extended)
+	row.Note = field(record, columns, colExtended)
 
 	switch {
 	case debit != "" && credit != "":
@@ -156,19 +153,6 @@ func parseRecord(record []string, rowNo int, columns map[string]int) ParsedRow {
 	}
 
 	return row
-}
-
-// composeNote folds the bank's transaction-type string and the extended text into
-// a single note, keeping whichever side is present.
-func composeNote(bankType, extended string) string {
-	switch {
-	case bankType != "" && extended != "":
-		return bankType + ": " + extended
-	case bankType != "":
-		return bankType
-	default:
-		return extended
-	}
 }
 
 // field returns the trimmed value of the named column for a record, or "" when the

--- a/internal/importer/csv_test.go
+++ b/internal/importer/csv_test.go
@@ -33,7 +33,7 @@ func TestParseReader(t *testing.T) {
 			wantDate:   "2026-06-23",
 			wantType:   model.TransactionTypeExpense,
 			wantAmount: "12.34",
-			wantNote:   "POS PURCHASE: COFFEE SHOP",
+			wantNote:   "COFFEE SHOP",
 		},
 		{
 			name:       "credit becomes income",
@@ -41,7 +41,7 @@ func TestParseReader(t *testing.T) {
 			wantDate:   "2026-01-05",
 			wantType:   model.TransactionTypeIncome,
 			wantAmount: "2000.00",
-			wantNote:   "DIRECT DEPOSIT: PAYROLL",
+			wantNote:   "PAYROLL",
 		},
 		{
 			name:       "note with only extended text",
@@ -122,7 +122,7 @@ func TestParseReaderMapsByHeaderNameIgnoringOrder(t *testing.T) {
 	if r.ParseErr != nil {
 		t.Fatalf("unexpected ParseErr: %v", r.ParseErr)
 	}
-	if r.Date != "2026-06-23" || r.Type != model.TransactionTypeExpense || r.AmountInput != "45.67" || r.Note != "POS: GROCERIES" {
+	if r.Date != "2026-06-23" || r.Type != model.TransactionTypeExpense || r.AmountInput != "45.67" || r.Note != "GROCERIES" {
 		t.Errorf("mismapped row: %+v", r)
 	}
 }


### PR DESCRIPTION
## Change

When importing a CSV, the transaction note was composed as `<Transaction Type>: <Extended Text>` (e.g. `POS PURCHASE: COFFEE SHOP`). This drops the Transaction Type prefix — the note is now the **Extended Text** value verbatim.

Also removes the now-unused `composeNote` helper and `colType` column mapping (dead code after this change).

## Testing

- `go build`, `go vet`, full suite: **100 tests pass**
- Updated parser test expectations to the extended-text-only note